### PR TITLE
Exclude xerces XML parser dependencies and fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: java
 jdk:
-#- openjdk7
-- oraclejdk8
-install:
+- openjdk8
 env:
   - TRAVIS_NODE_VERSION="8"
 install:
+  - sudo apt-get install -y ant ant-optional
   - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
   - npm install
 script: "ant all"

--- a/core/ivy.xml
+++ b/core/ivy.xml
@@ -18,7 +18,10 @@
 		<dependency org="javax.xml.parsers" name="jaxp-api" rev="1.4.5"/>
 
 		<!-- UPnP libs for NAT handling -->
-		<dependency org="commons-jxpath" name="commons-jxpath" rev="1.3"/>
+		<dependency org="commons-jxpath" name="commons-jxpath" rev="1.3">
+			<exclude module="xercesImpl"/>
+			<exclude module="xml-apis"/>
+		</dependency>
 		<dependency org="commons-logging" name="commons-logging" rev="1.2"/>
 		<dependency org="net" name="sbbi-upnplib" rev="1.0.4"/>
 


### PR DESCRIPTION
The core dependency "commons-jxpath" pulls the "xerces" XMLparser library. This particular version does not support schema validation and services that use it (like the MobSOS Surveys service) won't work because of it.
Excluding it restores the XMl parser sstate from before v0.8 and has not lead to any test failures thus far.

I also fixed the tests on Travis by switching from Oracle JSK 8 to Open JDK 8. The Oracle JDK 8 is not supported on Travis anymore.