### PR TITLE
fix missing symlink on /webapp/index.html

### DIFF
--- a/webconnector/build.xml
+++ b/webconnector/build.xml
@@ -197,12 +197,19 @@
             <arg value="audit"/>
             <arg value="fix"/>
         </exec>
-        -->
+    	-->
+        
 		<echo message="Building frontend ..."/>
 		<exec executable="npm" dir="frontend" failonerror="true">
 			<arg value="run"/>
 			<arg value="build"/>
 		</exec>
+		
+		<echo message="Fixing webapp symlink ..."/>
+		<exec executable="/bin/bash" failonerror="true">
+	    	<arg value="/app/las2peer/webconnector/fix_symlink.sh"/>
+	  	</exec>
+		
 	</target>
 
 	<target name="main_jar" depends="compile_main, build_frontend">

--- a/webconnector/fix_symlink.sh
+++ b/webconnector/fix_symlink.sh
@@ -1,0 +1,6 @@
+#/bin/bash
+echo "unlinking old symlink"
+touch /app/las2peer/webconnector/resources/webapp
+unlink /app/las2peer/webconnector/resources/webapp
+echo "linking new build"
+ln -svf /app/las2peer/webconnector/frontend/build/es6-bundled /app/las2peer/webconnector/resources/webapp


### PR DESCRIPTION
issue occurs when repo is deployed on linux (e.g. docker)