### PR TITLE
Access token fix

### DIFF
--- a/webconnector/frontend/src/node-frontend.js
+++ b/webconnector/frontend/src/node-frontend.js
@@ -336,7 +336,7 @@ class NodeFrontend extends PolymerElement {
     let req = this.$.ajaxLogin;
     req.headers = { Authorization: 'Basic ' + btoa(prefixedIdentifier + ':' + credentials.oidcSub) };
     if (((this._oidcUser || {}).access_token || "").length > 0) {
-      req.headers['access_token'] = this._oidcUser.access_token;
+      req.headers['access-token'] = this._oidcUser.access_token;
     }
     req.generateRequest();
   }

--- a/webconnector/src/main/java/i5/las2peer/connectors/webConnector/util/AuthenticationManager.java
+++ b/webconnector/src/main/java/i5/las2peer/connectors/webConnector/util/AuthenticationManager.java
@@ -36,7 +36,7 @@ public class AuthenticationManager {
 
 	private final L2pLogger logger = L2pLogger.getInstance(AuthenticationManager.class.getName());
 
-	public static final String ACCESS_TOKEN_KEY = "access_token";
+	public static final String ACCESS_TOKEN_KEY = "access-token";
 	public static final String OIDC_PROVIDER_KEY = "oidc_provider";
 
 	private final WebConnector connector;

--- a/webconnector/src/test/java/i5/las2peer/connectors/webConnector/WebConnectorTest.java
+++ b/webconnector/src/test/java/i5/las2peer/connectors/webConnector/WebConnectorTest.java
@@ -390,11 +390,11 @@ public class WebConnectorTest {
 			c.setLogin(testAgent.getIdentifier(), testPass);
 
 			// test auth params in GET
-			ClientResponse result = c.sendRequest("GET", "test/requesturi?param1=sadf&access_token=secret", "");
+			ClientResponse result = c.sendRequest("GET", "test/requesturi?param1=sadf&access-token=secret", "");
 			Assert.assertEquals(200, result.getHttpCode());
 			Assert.assertTrue(result.getResponse().contains("param1"));
 			Assert.assertFalse(result.getResponse().contains("secret"));
-			Assert.assertFalse(result.getResponse().contains("access_token"));
+			Assert.assertFalse(result.getResponse().contains("access-token"));
 
 			// test auth params in header
 			HashMap<String, String> headers = new HashMap<>();


### PR DESCRIPTION
Changed the header field sent along with the `/auth/login` request from `access_token` to `access-token` to avoid issues with NGINX reverse proxy