### PR TITLE
Use latest frontend statusbar to display current version in frontend

### DIFF
--- a/webconnector/build.xml
+++ b/webconnector/build.xml
@@ -187,6 +187,11 @@
 	<target name="junit_jars" depends=""/>
 
 	<target name="build_frontend" description="--> build the polymer frontend with bower">
+        <replaceregexp file="./frontend/src/node-frontend.js"
+                       match="subtitle=&quot;v(.*)&quot;"
+                       replace="subtitle=&quot;v${ivy.las2peer.version}&quot;"
+        />
+
 		<echo message="Installing dependencies (if needed) ..."/>
 		<exec executable="npm" dir="frontend" failonerror="true">
 			<arg value="install"/>

--- a/webconnector/frontend/package.json
+++ b/webconnector/frontend/package.json
@@ -41,7 +41,7 @@
     "@polymer/paper-tooltip": "^3.0.1",
     "@polymer/polymer": "^3.1.0",
     "@webcomponents/webcomponentsjs": "^2.2.1",
-    "las2peer-frontend-statusbar": "github:rwth-acis/las2peer-frontend-statusbar#0.2.1"
+    "las2peer-frontend-statusbar": "github:rwth-acis/las2peer-frontend-statusbar#0.3.0"
   },
   "devDependencies": {
     "polymer-cli": "^1.9.7",

--- a/webconnector/frontend/src/node-frontend.js
+++ b/webconnector/frontend/src/node-frontend.js
@@ -224,6 +224,7 @@ class NodeFrontend extends PolymerElement {
               oidcsilentsigninurl$="[[_loadUrl]]"
               loginoidctoken$="[[_oidcUser.access_token]]"
               loginoidcprovider="https://api.learning-layers.eu/o/oauth2"
+              subtitle="v{REPLACED_BY_ANT}"
             ></las2peer-frontend-statusbar>
 
           <iron-pages selected="[[page]]" attr-for-selected="name" fallback-selection="view404" role="main">


### PR DESCRIPTION
This PR contains the following changes:
The las2peer node frontend uses version 0.3.0 of the las2peer-frontend-statusbar. This allows to set a subtitle, which is used to display the current las2peer version.

Please note: I tried to test this merge locally, but the statusbar seems not to be updated. However, it also might be a problem with my machine and thus I think building with Jenkins once to test might be a better idea than spending hours to find my local problem.