### PR TITLE
Implement semver compatibility for service version

### DIFF
--- a/core/src/main/java/i5/las2peer/api/SemverVersion.java
+++ b/core/src/main/java/i5/las2peer/api/SemverVersion.java
@@ -7,9 +7,9 @@ import java.util.Comparator;
 import java.util.Objects;
 
 /**
- * a simple class managing a service version number in the format major.minor.patchversion-build where minor, patchversion
- * and build are optional
- *
+ * A simple class managing a semantic version number in the format
+ * {@code <major> "." <minor> "." <patch> "-" <pre-release> "+" <build>} (where minor, patch, pre-release and build
+ * are optional) or "*" (no version specified / matches all versions).
  */
 public class SemverVersion implements Serializable {
 

--- a/core/src/main/java/i5/las2peer/api/SemverVersion.java
+++ b/core/src/main/java/i5/las2peer/api/SemverVersion.java
@@ -1,5 +1,6 @@
 package i5.las2peer.api;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -10,7 +11,10 @@ import java.util.Objects;
  * and build are optional
  *
  */
-public class SemverVersion {
+public class SemverVersion implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String value;
 

--- a/core/src/main/java/i5/las2peer/api/SemverVersion.java
+++ b/core/src/main/java/i5/las2peer/api/SemverVersion.java
@@ -1,0 +1,342 @@
+package i5.las2peer.api;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Objects;
+
+/**
+ * a simple class managing a service version number in the format major.minor.patchversion-build where minor, patchversion
+ * and build are optional
+ *
+ */
+public class SemverVersion {
+
+    private String value;
+
+    protected Integer major = null;
+    protected Integer minor = null;
+    protected Integer patch = null;
+
+    protected String build = null;
+    protected String preRelease = null;
+
+    /**
+     * Generate a Version from String representation
+     *
+     * format : Semver {@code <major> "." <minor> "." <patch> "-" <pre-release> "+" <build>} (where minor, patch, pre-release and build are optional) or "*" (no version specified /
+     * matches all versions)
+     *
+     * @param version A version string representation to parse
+     * @throws IllegalArgumentException If the string contains no valid version representation
+     */
+    public SemverVersion(String version) throws IllegalArgumentException {
+        this.value = version;
+
+        if (version != null && !version.equals("*")) {
+            try {
+
+                String[] split;
+                String rawVersion;
+                // Separate additional metadata (pre-release/build)
+                if (hasPreRelease()) {
+                    String[] tokens;
+                    tokens = value.split("-", 2);
+
+                    split = tokens[1].split("\\+");
+                    if (split.length > 2) {
+                        throw new IllegalArgumentException("Syntax Error: more than one + in version string");
+                    } else if (split.length == 2) {
+                        this.preRelease = split[0];
+                        this.build = split[1];
+                    } else {
+                        this.preRelease = split[0];
+                    }
+
+                    if (this.preRelease != null && this.preRelease.contains("-")){
+                        throw new IllegalArgumentException("Syntax Error: pre-release should not contain a -.");
+                    }
+
+                    rawVersion = tokens[0];
+                }
+                else {
+                    split = version.split("\\+");
+                    if (split.length > 2) {
+                        throw new IllegalArgumentException("Syntax Error: more than one + in version string");
+                    }
+
+                    if (split.length == 2) {
+                        this.build = split[1];
+                    }
+                    rawVersion = split[0];
+                }
+
+                split = rawVersion.split("\\.");
+                if (split.length > 3) {
+                    throw new IllegalArgumentException(
+                            "Syntax Error: too many version numbers, a maximum of three is allowed");
+                }
+
+                this.major = Integer.valueOf(split[0]);
+                if (this.major < 0) {
+                    throw new IllegalArgumentException("Negative version numbers are not allowed!");
+                }
+
+                if (split.length > 1) {
+                    this.minor = Integer.valueOf(split[1]);
+                    if (this.minor < 0) {
+                        throw new IllegalArgumentException("Negative version numbers are not allowed!");
+                    }
+                } else {
+                    this.minor = null;
+                }
+
+                if (split.length > 2) {
+                    this.patch = Integer.valueOf(split[2]);
+                    if (this.patch < 0) {
+                        throw new IllegalArgumentException("Negative version numbers are not allowed!");
+                    }
+                } else {
+                    this.patch = null;
+                }
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException(
+                        "The given string contains invalid number representations: " + version, e);
+            }
+        }
+    }
+
+    /**
+     * generate a new ServiceVersion
+     *
+     * @param major Major version number part
+     * @param minor Minor version number part
+     * @param patch Patch version number part
+     * @param preRelease  pre-release version
+     * @param build build version
+     * @throws IllegalArgumentException If a version number part is smaller than 0
+     */
+    public SemverVersion(int major, int minor, int patch, String preRelease, String build) throws IllegalArgumentException {
+        this(major, minor, patch, preRelease);
+
+        this.build = build;
+    }
+
+    /**
+     * generate a new ServiceVersion
+     *
+     * @param major Major version number part
+     * @param minor Minor version number part
+     * @param patch Patch version number part
+     * @param preRelease  pre-release version
+     * @throws IllegalArgumentException If a version number part is smaller than 0
+     */
+    public SemverVersion(int major, int minor, int patch, String preRelease) throws IllegalArgumentException {
+        this(major, minor, patch);
+
+        this.preRelease = preRelease;
+    }
+
+    /**
+     * generate a new ServiceVersion
+     *
+     * @param major Major version number part
+     * @param minor Minor version number part
+     * @param patch Patch version number part
+     * @throws IllegalArgumentException If a version number part is smaller than 0
+     */
+    public SemverVersion(int major, int minor, int patch) throws IllegalArgumentException {
+        this(major, minor);
+        if (patch < 0) {
+            throw new IllegalArgumentException("Negative version numbers are not allowed!");
+        }
+        this.patch = patch;
+    }
+
+    /**
+     * generate a new ServiceVersion
+     *
+     * @param major Major version number part
+     * @param minor Minor version number part
+     * @throws IllegalArgumentException If a version number part is smaller than 0
+     */
+    public SemverVersion(int major, int minor) throws IllegalArgumentException {
+        this(major);
+        if (minor < 0) {
+            throw new IllegalArgumentException("Negative version numbers are not allowed!");
+        }
+        this.minor = minor;
+    }
+
+    /**
+     * generate a new ServiceVersion
+     *
+     * @param major Major version number part
+     * @throws IllegalArgumentException If a version number part is smaller than 0
+     */
+    public SemverVersion(int major) throws IllegalArgumentException {
+        if (major < 0) {
+            throw new IllegalArgumentException("Negative version numbers are not allowed!");
+        }
+        this.major = major;
+    }
+
+    /**
+     * Identify if this version contains a pre-release according to semver specification
+     * @return if this version contains a pre-release
+     */
+    private boolean hasPreRelease() {
+
+        int firstIndexOfPlus = value.indexOf("+");
+        int firstIndexOfHyphen = value.indexOf("-");
+
+        if (firstIndexOfHyphen == -1) {
+            return false;
+        }
+
+        return firstIndexOfPlus == -1 || firstIndexOfHyphen < firstIndexOfPlus;
+    }
+
+    /**
+     * compares to version and checks for equality
+     *
+     * @param v Another service version to compare to
+     * @return true, if this version is the same as the given one
+     */
+    public boolean equals(SemverVersion v) {
+        return v.toVersionString(false).equals(this.toVersionString(false));
+    }
+
+    /**
+     * compares this version with any object
+     *
+     * if the given object is a String, the string representation of this version is compared to the given string
+     *
+     * @param o Another object to check
+     * @return true, if the given object is a version and the same as this one
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof SemverVersion) {
+            return this.equals((SemverVersion) o);
+        } else if (o instanceof String) {
+            return this.toString().equals(o);
+        } else {
+            return super.equals(o);
+        }
+    }
+
+    /**
+     * since equals is overridden, we should implement an own hashCode.
+     *
+     * @return a hash code as int
+     */
+    @Override
+    public int hashCode() {
+        return (this.toString()).hashCode();
+    }
+
+    /**
+     * get the minor version number
+     *
+     * @return minor version number
+     */
+    public int getMinor() {
+        if (minor == null) {
+            return 0;
+        }
+        return minor;
+    }
+
+    /**
+     * get the major version number
+     *
+     * @return major version number
+     */
+    public int getMajor() {
+        if (major == null) {
+            return 0;
+        }
+        return major;
+    }
+
+
+    /**
+     * get the patch version of the minor version number
+     *
+     * @return patch version number of minor
+     */
+    public int getPatch() {
+        if (patch == null) {
+            return 0;
+        }
+        return patch;
+    }
+
+    /**
+     * get the subversion of the minor version number
+     *
+     * @return subversion number of minor
+     * @deprecated use {@link #getPatch()} instead
+     */
+    public int getSub() {
+        return this.getPatch();
+    }
+
+
+    /**
+     * get the build number of this (patch)version
+     *
+     * @return build number
+     */
+    public String getBuild() {
+        if (build == null) {
+            return "";
+        }
+        return build;
+    }
+
+    public String getPreRelease() {
+        if (preRelease == null) {
+            return "";
+        }
+        return preRelease;
+    }
+
+    /**
+     * @return a String representation of this version
+     */
+    @Override
+    public String toString() {
+        return toVersionString(true);
+    }
+
+    /**
+     * Returns the version without optional information
+     * @param includeBuild should build information be included?
+     * @return  a String representation of this version
+     */
+    private String toVersionString(Boolean includeBuild) {
+        if (major == null) {
+            return "*";
+        }
+
+        String result = "" + major;
+        if (minor != null) {
+            result += "." + minor;
+            if (patch != null) {
+                result += "." + patch;
+            }
+        }
+
+        if (preRelease != null) {
+            result += "-" + preRelease;
+        }
+
+        if (build != null && includeBuild) {
+            result += "+" + build;
+        }
+
+        return result;
+    }
+}

--- a/core/src/main/java/i5/las2peer/api/p2p/ServiceVersion.java
+++ b/core/src/main/java/i5/las2peer/api/p2p/ServiceVersion.java
@@ -13,10 +13,7 @@ import java.util.Objects;
  * and build are optional
  *
  */
-public class ServiceVersion extends SemverVersion implements Comparable<ServiceVersion>, Serializable {
-
-	@Serial
-	private static final long serialVersionUID = 1L;
+public class ServiceVersion extends SemverVersion implements Comparable<ServiceVersion> {
 
 	/**
 	 * Generate a Version from String representation

--- a/core/src/main/java/i5/las2peer/api/p2p/ServiceVersion.java
+++ b/core/src/main/java/i5/las2peer/api/p2p/ServiceVersion.java
@@ -54,6 +54,11 @@ public class ServiceVersion implements Comparable<ServiceVersion>, Serializable 
 					} else {
 						this.preRelease = split[0];
 					}
+
+					if (this.preRelease != null && this.preRelease.contains("-")){
+						throw new IllegalArgumentException("Syntax Error: pre-release should not contain a -.");
+					}
+
 					rawVersion = tokens[0];
 				}
 				else {
@@ -109,13 +114,29 @@ public class ServiceVersion implements Comparable<ServiceVersion>, Serializable 
 	 * @param major Major version number part
 	 * @param minor Minor version number part
 	 * @param patch Patch version number part
-	 * @param build Build number
+	 * @param preRelease  pre-release version
+	 * @param build build version
 	 * @throws IllegalArgumentException If a version number part is smaller than 0
 	 */
-	public ServiceVersion(int major, int minor, int patch, String build) throws IllegalArgumentException {
-		this(major, minor, patch);
+	public ServiceVersion(int major, int minor, int patch, String preRelease, String build) throws IllegalArgumentException {
+		this(major, minor, patch, preRelease);
 
 		this.build = build;
+	}
+
+	/**
+	 * generate a new ServiceVersion
+	 *
+	 * @param major Major version number part
+	 * @param minor Minor version number part
+	 * @param patch Patch version number part
+	 * @param preRelease  pre-release version
+	 * @throws IllegalArgumentException If a version number part is smaller than 0
+	 */
+	public ServiceVersion(int major, int minor, int patch, String preRelease) throws IllegalArgumentException {
+		this(major, minor, patch);
+
+		this.preRelease = preRelease;
 	}
 
 	/**
@@ -402,6 +423,13 @@ public class ServiceVersion implements Comparable<ServiceVersion>, Serializable 
 		return build;
 	}
 
+	public String getPreRelease() {
+		if (preRelease == null) {
+			return "";
+		}
+		return preRelease;
+	}
+
 	/**
 	 * @return a String representation of this version
 	 */
@@ -485,8 +513,20 @@ public class ServiceVersion implements Comparable<ServiceVersion>, Serializable 
 			return false;
 		}
 
+		if (required.preRelease == null) {
+			return true;
+		}
+
+		if (!Objects.equals(required.preRelease, this.preRelease)) {
+			return false;
+		}
+
 		if (required.build == null) {
 			return true;
+		}
+
+		if (this.build == null || !Objects.equals(required.build, this.build)) {
+			return false;
 		}
 
 		return true;

--- a/core/src/main/java/i5/las2peer/api/p2p/ServiceVersion.java
+++ b/core/src/main/java/i5/las2peer/api/p2p/ServiceVersion.java
@@ -41,7 +41,7 @@ public class ServiceVersion implements Comparable<ServiceVersion>, Serializable 
 				String[] split;
 				String rawVersion;
 				// Separate additional metadata (pre-release/build)
-				if (hasPreRelease(version)) {
+				if (hasPreRelease()) {
 					String[] tokens;
 					tokens = value.split("-", 2);
 
@@ -185,10 +185,9 @@ public class ServiceVersion implements Comparable<ServiceVersion>, Serializable 
 
 	/**
 	 * Identify if this version contains a pre-release according to semver specification
-	 * @param version passed version string
 	 * @return if this version contains a pre-release
 	 */
-	private boolean hasPreRelease(String version) {
+	private boolean hasPreRelease() {
 
 		int firstIndexOfPlus = value.indexOf("+");
 		int firstIndexOfHyphen = value.indexOf("-");

--- a/core/src/main/java/i5/las2peer/api/p2p/ServiceVersion.java
+++ b/core/src/main/java/i5/las2peer/api/p2p/ServiceVersion.java
@@ -1,5 +1,8 @@
 package i5.las2peer.api.p2p;
 
+import i5.las2peer.api.SemverVersion;
+
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -10,18 +13,10 @@ import java.util.Objects;
  * and build are optional
  *
  */
-public class ServiceVersion implements Comparable<ServiceVersion>, Serializable {
+public class ServiceVersion extends SemverVersion implements Comparable<ServiceVersion>, Serializable {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
-
-	private String value;
-
-	private Integer major = null;
-	private Integer minor = null;
-	private Integer patch = null;
-
-	private String build = null;
-	private String preRelease = null;
 
 	/**
 	 * Generate a Version from String representation
@@ -33,79 +28,7 @@ public class ServiceVersion implements Comparable<ServiceVersion>, Serializable 
 	 * @throws IllegalArgumentException If the string contains no valid version representation
 	 */
 	public ServiceVersion(String version) throws IllegalArgumentException {
-		this.value = version;
-
-		if (version != null && !version.equals("*")) {
-			try {
-
-				String[] split;
-				String rawVersion;
-				// Separate additional metadata (pre-release/build)
-				if (hasPreRelease()) {
-					String[] tokens;
-					tokens = value.split("-", 2);
-
-					split = tokens[1].split("\\+");
-					if (split.length > 2) {
-						throw new IllegalArgumentException("Syntax Error: more than one + in version string");
-					} else if (split.length == 2) {
-						this.preRelease = split[0];
-						this.build = split[1];
-					} else {
-						this.preRelease = split[0];
-					}
-
-					if (this.preRelease != null && this.preRelease.contains("-")){
-						throw new IllegalArgumentException("Syntax Error: pre-release should not contain a -.");
-					}
-
-					rawVersion = tokens[0];
-				}
-				else {
-					split = version.split("\\+");
-					if (split.length > 2) {
-						throw new IllegalArgumentException("Syntax Error: more than one + in version string");
-					}
-
-					if (split.length == 2) {
-						this.build = split[1];
-					}
-					rawVersion = split[0];
-				}
-
-				split = rawVersion.split("\\.");
-				if (split.length > 3) {
-					throw new IllegalArgumentException(
-							"Syntax Error: too many version numbers, a maximum of three is allowed");
-				}
-
-				this.major = Integer.valueOf(split[0]);
-				if (this.major < 0) {
-					throw new IllegalArgumentException("Negative version numbers are not allowed!");
-				}
-
-				if (split.length > 1) {
-					this.minor = Integer.valueOf(split[1]);
-					if (this.minor < 0) {
-						throw new IllegalArgumentException("Negative version numbers are not allowed!");
-					}
-				} else {
-					this.minor = null;
-				}
-
-				if (split.length > 2) {
-					this.patch = Integer.valueOf(split[2]);
-					if (this.patch < 0) {
-						throw new IllegalArgumentException("Negative version numbers are not allowed!");
-					}
-				} else {
-					this.patch = null;
-				}
-			} catch (NumberFormatException e) {
-				throw new IllegalArgumentException(
-						"The given string contains invalid number representations: " + version, e);
-			}
-		}
+		super(version);
 	}
 
 	/**
@@ -119,9 +42,7 @@ public class ServiceVersion implements Comparable<ServiceVersion>, Serializable 
 	 * @throws IllegalArgumentException If a version number part is smaller than 0
 	 */
 	public ServiceVersion(int major, int minor, int patch, String preRelease, String build) throws IllegalArgumentException {
-		this(major, minor, patch, preRelease);
-
-		this.build = build;
+		super(major, minor, patch, preRelease, build);
 	}
 
 	/**
@@ -134,9 +55,7 @@ public class ServiceVersion implements Comparable<ServiceVersion>, Serializable 
 	 * @throws IllegalArgumentException If a version number part is smaller than 0
 	 */
 	public ServiceVersion(int major, int minor, int patch, String preRelease) throws IllegalArgumentException {
-		this(major, minor, patch);
-
-		this.preRelease = preRelease;
+		super(major, minor, patch, preRelease);
 	}
 
 	/**
@@ -148,11 +67,7 @@ public class ServiceVersion implements Comparable<ServiceVersion>, Serializable 
 	 * @throws IllegalArgumentException If a version number part is smaller than 0
 	 */
 	public ServiceVersion(int major, int minor, int patch) throws IllegalArgumentException {
-		this(major, minor);
-		if (patch < 0) {
-			throw new IllegalArgumentException("Negative version numbers are not allowed!");
-		}
-		this.patch = patch;
+		super(major, minor,patch);
 	}
 
 	/**
@@ -163,11 +78,7 @@ public class ServiceVersion implements Comparable<ServiceVersion>, Serializable 
 	 * @throws IllegalArgumentException If a version number part is smaller than 0
 	 */
 	public ServiceVersion(int major, int minor) throws IllegalArgumentException {
-		this(major);
-		if (minor < 0) {
-			throw new IllegalArgumentException("Negative version numbers are not allowed!");
-		}
-		this.minor = minor;
+		super(major, minor);
 	}
 
 	/**
@@ -177,26 +88,7 @@ public class ServiceVersion implements Comparable<ServiceVersion>, Serializable 
 	 * @throws IllegalArgumentException If a version number part is smaller than 0
 	 */
 	public ServiceVersion(int major) throws IllegalArgumentException {
-		if (major < 0) {
-			throw new IllegalArgumentException("Negative version numbers are not allowed!");
-		}
-		this.major = major;
-	}
-
-	/**
-	 * Identify if this version contains a pre-release according to semver specification
-	 * @return if this version contains a pre-release
-	 */
-	private boolean hasPreRelease() {
-
-		int firstIndexOfPlus = value.indexOf("+");
-		int firstIndexOfHyphen = value.indexOf("-");
-
-		if (firstIndexOfHyphen == -1) {
-			return false;
-		}
-
-		return firstIndexOfPlus == -1 || firstIndexOfHyphen < firstIndexOfPlus;
+		super(major);
 	}
 
 	/**
@@ -323,148 +215,6 @@ public class ServiceVersion implements Comparable<ServiceVersion>, Serializable 
 		return this.isBetween(new ServiceVersion(smaller), new ServiceVersion(larger));
 	}
 
-	/**
-	 * compares to version and checks for equality
-	 *
-	 * @param v Another service version to compare to
-	 * @return true, if this version is the same as the given one
-	 */
-	public boolean equals(ServiceVersion v) {
-		return v.toVersionString(false).equals(this.toVersionString(false));
-	}
-
-	/**
-	 * compares this version with any object
-	 *
-	 * if the given object is a String, the string representation of this version is compared to the given string
-	 *
-	 * @param o Another object to check
-	 * @return true, if the given object is a version and the same as this one
-	 */
-	@Override
-	public boolean equals(Object o) {
-		if (o instanceof ServiceVersion) {
-			return this.equals((ServiceVersion) o);
-		} else if (o instanceof String) {
-			return this.toString().equals(o);
-		} else {
-			return super.equals(o);
-		}
-	}
-
-	/**
-	 * since equals is overridden, we should implement an own hashCode.
-	 *
-	 * @return a hash code as int
-	 */
-	@Override
-	public int hashCode() {
-		return (this.toString()).hashCode();
-	}
-
-	/**
-	 * get the minor version number
-	 *
-	 * @return minor version number
-	 */
-	public int getMinor() {
-		if (minor == null) {
-			return 0;
-		}
-		return minor;
-	}
-
-	/**
-	 * get the major version number
-	 *
-	 * @return major version number
-	 */
-	public int getMajor() {
-		if (major == null) {
-			return 0;
-		}
-		return major;
-	}
-
-
-	/**
-	 * get the patch version of the minor version number
-	 *
-	 * @return patcher version number of minor
-	 */
-	public int getPatch() {
-		if (patch == null) {
-			return 0;
-		}
-		return patch;
-	}
-
-	/**
-	 * get the subversion of the minor version number
-	 *
-	 * @return suberversion number of minor
-	 * @deprecated use {@link #getPatch()} instead
-	 */
-	public int getSub() {
-		return this.getPatch();
-	}
-
-
-	/**
-	 * get the build number of this (patch)version
-	 *
-	 * @return build number
-	 */
-	public String getBuild() {
-		if (build == null) {
-			return "";
-		}
-		return build;
-	}
-
-	public String getPreRelease() {
-		if (preRelease == null) {
-			return "";
-		}
-		return preRelease;
-	}
-
-	/**
-	 * @return a String representation of this version
-	 */
-	@Override
-	public String toString() {
-		return toVersionString(true);
-	}
-
-	/**
-	 * Returns the version without optional information
-	 * @param includeBuild should build information be included?
-	 * @return  a String representation of this version
-	 */
-	private String toVersionString(Boolean includeBuild) {
-		if (major == null) {
-			return "*";
-		}
-
-		String result = "" + major;
-		if (minor != null) {
-			result += "." + minor;
-			if (patch != null) {
-				result += "." + patch;
-			}
-		}
-
-		if (preRelease != null) {
-			result += "-" + preRelease;
-		}
-
-		if (build != null && includeBuild) {
-			result += "+" + build;
-		}
-
-		return result;
-	}
 	/**
 	 * implementation of Comparable
 	 *

--- a/core/src/main/java/i5/las2peer/api/p2p/ServiceVersion.java
+++ b/core/src/main/java/i5/las2peer/api/p2p/ServiceVersion.java
@@ -9,9 +9,9 @@ import java.util.Comparator;
 import java.util.Objects;
 
 /**
- * a simple class managing a service version number in the format major.minor.patchversion-build where minor, patchversion
- * and build are optional
- *
+ * A simple class managing a service version number in the format
+ * {@code <major> "." <minor> "." <patch> "-" <pre-release> "+" <build>} (where minor, patch, pre-release and build
+ * are optional) or "*" (no version specified / matches all versions).
  */
 public class ServiceVersion extends SemverVersion implements Comparable<ServiceVersion> {
 

--- a/core/src/main/java/i5/las2peer/classLoaders/libraries/FileSystemRepository.java
+++ b/core/src/main/java/i5/las2peer/classLoaders/libraries/FileSystemRepository.java
@@ -284,7 +284,7 @@ public class FileSystemRepository implements Repository {
 
 		File[] entries = f.listFiles();
 
-		Pattern versionPattern = Pattern.compile("-(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$");
+		Pattern versionPattern = Pattern.compile("-(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(\\.(0|[1-9]\\d*))?(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$");
 
 		for (File entry : entries) {
 			if (entry.isDirectory()) {

--- a/core/src/main/java/i5/las2peer/classLoaders/libraries/FileSystemRepository.java
+++ b/core/src/main/java/i5/las2peer/classLoaders/libraries/FileSystemRepository.java
@@ -31,7 +31,7 @@ public class FileSystemRepository implements Repository {
 
 	/**
 	 * create a repository for the given directory, non-recursive
-	 * 
+	 *
 	 * @param directory A directory path name to use as repository
 	 */
 	public FileSystemRepository(String directory) {
@@ -40,7 +40,7 @@ public class FileSystemRepository implements Repository {
 
 	/**
 	 * create a repository for the given directory
-	 * 
+	 *
 	 * @param directory A directory path name to use as repository
 	 * @param recursive If true, recursion is used for sub-directories.
 	 */
@@ -50,7 +50,7 @@ public class FileSystemRepository implements Repository {
 
 	/**
 	 * create a repository for the given directories, non-recursive
-	 * 
+	 *
 	 * @param directories An array of directory path names to use as repository
 	 */
 	public FileSystemRepository(String[] directories) {
@@ -59,7 +59,7 @@ public class FileSystemRepository implements Repository {
 
 	/**
 	 * create a repository for the given directories
-	 * 
+	 *
 	 * @param directories An array of directory path names to use as repository
 	 * @param recursive If true, recursion is used for sub-directories.
 	 */
@@ -69,7 +69,7 @@ public class FileSystemRepository implements Repository {
 
 	/**
 	 * create a repository for the given directories
-	 * 
+	 *
 	 * @param directories A bunch of directory path names to use as repository
 	 * @param recursive If true, recursion is used for sub-directories.
 	 */
@@ -82,7 +82,7 @@ public class FileSystemRepository implements Repository {
 
 	/**
 	 * get the newest library for the given name
-	 * 
+	 *
 	 * @param name A library name to search for
 	 * @return Returns a LoadedLibrary for the requested library name
 	 * @throws LibraryNotFoundException If the library could not be found in this repository
@@ -117,7 +117,7 @@ public class FileSystemRepository implements Repository {
 
 	/**
 	 * get a library matching name and version of the given identifier
-	 * 
+	 *
 	 * @param lib A library identifier
 	 * @return Returns a LoadedLibrary for the requested library identifier
 	 * @throws LibraryNotFoundException If the library could not be found in this repository
@@ -149,7 +149,7 @@ public class FileSystemRepository implements Repository {
 
 	/**
 	 * get an array with all versions found for the given library name
-	 * 
+	 *
 	 * @param libraryName A canonical library name
 	 * @return array with all available versions of the given library
 	 */
@@ -159,7 +159,7 @@ public class FileSystemRepository implements Repository {
 
 	/**
 	 * get a collection with all versions found for the given library name
-	 * 
+	 *
 	 * @param libraryName A canonical library name
 	 * @return a collections with all versions of the given library
 	 */
@@ -174,7 +174,7 @@ public class FileSystemRepository implements Repository {
 
 	/**
 	 * get an array with found jar files within this repository
-	 * 
+	 *
 	 * @return an array with all libraries in this repository
 	 */
 	public String[] getAllLibraries() {
@@ -184,7 +184,7 @@ public class FileSystemRepository implements Repository {
 
 	/**
 	 * get a collection with all found jar files within this repository
-	 * 
+	 *
 	 * @return a collection with all libraries in this repository
 	 */
 	public Collection<String> getLibraryCollection() {
@@ -205,7 +205,7 @@ public class FileSystemRepository implements Repository {
 
 	/**
 	 * helper method to get the last modification date of a directory
-	 * 
+	 *
 	 * @param dir A directory
 	 * @param recursive If true also files inside the directory are considered
 	 * @return Returns the last modified date in epoch format
@@ -234,7 +234,7 @@ public class FileSystemRepository implements Repository {
 
 	/**
 	 * checks if there were changes made in the folder and re-reads repositories if so
-	 * 
+	 *
 	 * @param force if true, the repository will be updated independent from last modification
 	 */
 	private void updateRepository(boolean force) {
@@ -265,7 +265,7 @@ public class FileSystemRepository implements Repository {
 
 	/**
 	 * look for jars in the given directory, search recursive, if flag is set
-	 * 
+	 *
 	 * @param directory
 	 */
 	private void searchJars(String directory) {
@@ -284,7 +284,7 @@ public class FileSystemRepository implements Repository {
 
 		File[] entries = f.listFiles();
 
-		Pattern versionPattern = Pattern.compile("-[0-9]+(?:.[0-9]+(?:.[0-9]+)?)?(?:-[0-9]+)?$");
+		Pattern versionPattern = Pattern.compile("-(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$");
 
 		for (File entry : entries) {
 			if (entry.isDirectory()) {
@@ -314,7 +314,7 @@ public class FileSystemRepository implements Repository {
 
 	/**
 	 * register a found jar file to the hashtable of available jars in this repository
-	 * 
+	 *
 	 * @param file
 	 * @param name
 	 * @param version

--- a/core/src/main/java/i5/las2peer/classLoaders/libraries/LibraryVersion.java
+++ b/core/src/main/java/i5/las2peer/classLoaders/libraries/LibraryVersion.java
@@ -11,8 +11,6 @@ import i5.las2peer.api.p2p.ServiceVersion;
  */
 public class LibraryVersion  extends ServiceVersion {
 
-	private int major = 0;
-
 	/**
 	 * Generate a Version from String representation
 	 *

--- a/core/src/main/java/i5/las2peer/classLoaders/libraries/LibraryVersion.java
+++ b/core/src/main/java/i5/las2peer/classLoaders/libraries/LibraryVersion.java
@@ -1,5 +1,6 @@
 package i5.las2peer.classLoaders.libraries;
 
+import i5.las2peer.api.SemverVersion;
 import i5.las2peer.api.p2p.ServiceVersion;
 
 /**
@@ -9,7 +10,7 @@ import i5.las2peer.api.p2p.ServiceVersion;
  *
  *
  */
-public class LibraryVersion  extends ServiceVersion {
+public class LibraryVersion  extends SemverVersion {
 
 	/**
 	 * Generate a Version from String representation

--- a/core/src/main/java/i5/las2peer/classLoaders/libraries/LibraryVersion.java
+++ b/core/src/main/java/i5/las2peer/classLoaders/libraries/LibraryVersion.java
@@ -4,20 +4,17 @@ import i5.las2peer.api.SemverVersion;
 import i5.las2peer.api.p2p.ServiceVersion;
 
 /**
- * a simple class managing a library version number in the format major.minor.subversion-build where minor, subversion
- * and build are optional
- *
- *
- *
+ * A simple class managing a library version number in the format
+ * {@code <major> "." <minor> "." <patch> "-" <pre-release> "+" <build>} (where minor, patch, pre-release and build
+ * are optional) or "*" (no version specified / matches all versions).
  */
 public class LibraryVersion  extends SemverVersion {
 
 	/**
 	 * Generate a Version from String representation
 	 *
-	 * format : major.minor.sub-build
-	 *
-	 * minor, subversion and build are optional
+	 * format : Semver {@code <major> "." <minor> "." <patch> "-" <pre-release> "+" <build>} (where minor, patch,
+	 * pre-release and build are optional) or "*" (no version specified / matches all versions)
 	 *
 	 * @param version A version string representation
 	 * @throws IllegalArgumentException If the string contains no valid version representation

--- a/core/src/main/java/i5/las2peer/classLoaders/libraries/LibraryVersion.java
+++ b/core/src/main/java/i5/las2peer/classLoaders/libraries/LibraryVersion.java
@@ -1,227 +1,89 @@
 package i5.las2peer.classLoaders.libraries;
 
+import i5.las2peer.api.p2p.ServiceVersion;
+
 /**
  * a simple class managing a library version number in the format major.minor.subversion-build where minor, subversion
  * and build are optional
- * 
- * 
+ *
+ *
  *
  */
-public class LibraryVersion {
+public class LibraryVersion  extends ServiceVersion {
 
 	private int major = 0;
-	private Integer minor = null;
-	private Integer sub = null;
-	private Integer build = null;
 
 	/**
 	 * Generate a Version from String representation
-	 * 
+	 *
 	 * format : major.minor.sub-build
-	 * 
+	 *
 	 * minor, subversion and build are optional
-	 * 
+	 *
 	 * @param version A version string representation
 	 * @throws IllegalArgumentException If the string contains no valid version representation
 	 */
 	public LibraryVersion(String version) throws IllegalArgumentException {
-		try {
-			int posMinus = version.indexOf("-");
-			String[] split;
-			if (posMinus >= 0) {
-				split = version.split("-");
-				if (split.length != 2)
-					throw new IllegalArgumentException("Syntax Error: more than one - in version string");
-
-				this.build = Integer.valueOf(split[1]);
-				version = split[0];
-
-				if (this.build < 0)
-					throw new IllegalArgumentException("Negative version numbers are not allowed!");
-			}
-
-			split = version.split("\\.");
-			if (split.length > 3)
-				throw new IllegalArgumentException(
-						"Syntax Error: too many version numbers, a maximum of three is allowed");
-
-			this.major = Integer.valueOf(split[0]);
-			if (this.major < 0)
-				throw new IllegalArgumentException("Negative version numbers are not allowed!");
-
-			if (split.length > 1) {
-				this.minor = Integer.valueOf(split[1]);
-				if (this.minor < 0)
-					throw new IllegalArgumentException("Negative version numbers are not allowed!");
-			} else
-				this.minor = null;
-
-			if (split.length > 2) {
-				this.sub = Integer.valueOf(split[2]);
-				if (this.sub < 0)
-					throw new IllegalArgumentException("Negative version numbers are not allowed!");
-			} else
-				this.sub = null;
-		} catch (NumberFormatException e) {
-			throw new IllegalArgumentException("The given string contains invalid number representations: " + version,
-					e);
-		}
-
+		super(version);
 	}
 
 	/**
 	 * generate a new LibraryVersion
-	 * 
+	 *
 	 * @param major Major version number part
 	 * @param minor Minor version number part
-	 * @param sub Sub version number part
-	 * @param build Build number
+	 * @param patch Sub version number part
+	 * @param preRelease pre-release version
+	 * @param build build version
 	 * @throws IllegalArgumentException If a version number part is smaller than 0
 	 */
-	public LibraryVersion(int major, int minor, int sub, int build) throws IllegalArgumentException {
-		this(major, minor, sub);
-		if (build < 0)
-			throw new IllegalArgumentException("Negative version numbers are not allowed!");
-
-		this.build = build;
+	public LibraryVersion(int major, int minor, int patch, String preRelease, String build) throws IllegalArgumentException {
+		super(major, minor, patch, preRelease, build);
 	}
 
 	/**
 	 * generate a new LibraryVersion
-	 * 
+	 *
 	 * @param major Major version number part
 	 * @param minor Minor version number part
-	 * @param sub Sub version number part
+	 * @param patch Sub version number part
+	 * @param preRelease pre-release version
 	 * @throws IllegalArgumentException If a version number part is smaller than 0
 	 */
-	public LibraryVersion(int major, int minor, int sub) throws IllegalArgumentException {
-		this(major, minor);
-		if (sub < 0)
-			throw new IllegalArgumentException("Negative version numbers are not allowed!");
-		this.sub = sub;
+	public LibraryVersion(int major, int minor, int patch, String preRelease) throws IllegalArgumentException {
+		super(major, minor, patch, preRelease);
 	}
 
 	/**
 	 * generate a new LibraryVersion
-	 * 
+	 *
+	 * @param major Major version number part
+	 * @param minor Minor version number part
+	 * @param patch patch version number part
+	 * @throws IllegalArgumentException If a version number part is smaller than 0
+	 */
+	public LibraryVersion(int major, int minor, int patch) throws IllegalArgumentException {
+		super(major, minor, patch);
+	}
+
+	/**
+	 * generate a new LibraryVersion
+	 *
 	 * @param major Major version number part
 	 * @param minor Minor version number part
 	 * @throws IllegalArgumentException If a version number part is smaller than 0
 	 */
 	public LibraryVersion(int major, int minor) throws IllegalArgumentException {
-		this(major);
-		if (minor < 0)
-			throw new IllegalArgumentException("Negative version numbers are not allowed!");
-		this.minor = minor;
+		super(major, minor);
 	}
 
 	/**
 	 * generate a new LibraryVersion
-	 * 
+	 *
 	 * @param major Major version number part
 	 * @throws IllegalArgumentException If a version number part is smaller than 0
 	 */
 	public LibraryVersion(int major) throws IllegalArgumentException {
-		if (major < 0)
-			throw new IllegalArgumentException("Negative version numbers are not allowed!");
-		this.major = major;
-	}
-
-	/**
-	 * compares to version and checks for equality
-	 * 
-	 * @param v Another library version to check
-	 * @return true, if this version is the same as the given one
-	 */
-	public boolean equals(LibraryVersion v) {
-		return v.toString().equals(this.toString());
-	}
-
-	/**
-	 * compares this version with any object
-	 * 
-	 * if the given object is a String, the string representation of this version is compared to the given string
-	 * 
-	 * @param o Another version string to check
-	 * @return true, if the given object is a version and the same as this one
-	 */
-	@Override
-	public boolean equals(Object o) {
-		if (o instanceof LibraryVersion)
-			return this.equals((LibraryVersion) o);
-		else if (o instanceof String)
-			return this.toString().equals(o);
-		else
-			return super.equals(o);
-	}
-
-	/**
-	 * since equals is overridden, we should implement an own hashCode.
-	 * 
-	 * @return a hash code as int
-	 */
-	@Override
-	public int hashCode() {
-		return (this.toString()).hashCode();
-	}
-
-	/**
-	 * get the minor version number
-	 * 
-	 * @return minor version number
-	 */
-	public int getMinor() {
-		if (minor == null)
-			return 0;
-		return minor;
-	}
-
-	/**
-	 * get the major version number
-	 * 
-	 * @return major version number
-	 */
-	public int getMajor() {
-		return major;
-	}
-
-	/**
-	 * get the subversion of the minor version number
-	 * 
-	 * @return suberverion number of minor
-	 */
-	public int getSub() {
-		if (sub == null)
-			return 0;
-		return sub;
-	}
-
-	/**
-	 * get the build number of this (sub)version
-	 * 
-	 * @return build number
-	 */
-	public int getBuild() {
-		if (build == null)
-			return 0;
-		return build;
-	}
-
-	/**
-	 * @return a String representation of this version
-	 */
-	@Override
-	public String toString() {
-		String result = "" + major;
-		if (minor != null) {
-			result += "." + minor;
-			if (sub != null)
-				result += "." + sub;
-		}
-
-		if (build != null)
-			result += "-" + build;
-
-		return result;
+		super(major);
 	}
 }

--- a/core/src/main/java/i5/las2peer/p2p/EthereumNode.java
+++ b/core/src/main/java/i5/las2peer/p2p/EthereumNode.java
@@ -111,7 +111,7 @@ public class EthereumNode extends PastryNodeImpl {
 		String className = nameVersion.getSimpleClassName();
 		int versionMajor = nameVersion.getVersion().getMajor();
 		int versionMinor = nameVersion.getVersion().getMinor();
-		int versionPatch = nameVersion.getVersion().getSub();
+		int versionPatch = nameVersion.getVersion().getPatch();
 		String nodeId = getPastryNode().getId().toStringFull();
 		try {
 			registryClient.announceDeployment(serviceName, className, versionMajor, versionMinor, versionPatch, nodeId);
@@ -139,7 +139,7 @@ public class EthereumNode extends PastryNodeImpl {
 		String className = nameVersion.getSimpleClassName();
 		int versionMajor = nameVersion.getVersion().getMajor();
 		int versionMinor = nameVersion.getVersion().getMinor();
-		int versionPatch = nameVersion.getVersion().getSub();
+		int versionPatch = nameVersion.getVersion().getPatch();
 		String nodeId = getPastryNode().getId().toStringFull();
 		try {
 			registryClient.announceDeploymentEnd(serviceName, className, versionMajor, versionMinor, versionPatch, nodeId);
@@ -233,7 +233,7 @@ public class EthereumNode extends PastryNodeImpl {
 	public float getAgentReputation(String adminName, String adminEmail) {
 		// query node admin reputation
 		AgentImpl ethAgentAgent = null;
-		
+
 		try {
 			ethAgentAgent = getAgentByDetail(null, adminName, adminEmail);
 			ethAgentAgent = getAgent(ethAgentAgent.getIdentifier());
@@ -264,9 +264,9 @@ public class EthereumNode extends PastryNodeImpl {
 	private boolean agentMatchesUserRegistryData(EthereumAgent agent) throws EthereumException {
 		try {
 			logger.fine("[ETH] matching agent ("+ agent.getLoginName() +") to registry");
-			
+
 			UserData userInBlockchain = registryClient.getUser(agent.getLoginName());
-			
+
 			logger.finer("MATCHING ID? " + String.valueOf(userInBlockchain.getAgentId().equals(agent.getIdentifier())));
 			logger.finer("MATCHING PubKey? " + String.valueOf(userInBlockchain.getPublicKey().equals(agent.getPublicKey())));
 			// damn, we might not be able to compare the ethereum address, because it may be null if the agent is locked
@@ -352,9 +352,9 @@ public class EthereumNode extends PastryNodeImpl {
 	public ReadWriteRegistryClient getRegistryClient() {
 		return registryClient;
 	}
-	
+
 	//public void registerProfile(EthereumAgent author) throws EthereumException {
 	//	registryClient.registerReputationProfile(author);
 	//}
-	 
+
 }

--- a/core/src/test/java/i5/las2peer/classLoaders/libraries/LibraryIdentifierTest.java
+++ b/core/src/test/java/i5/las2peer/classLoaders/libraries/LibraryIdentifierTest.java
@@ -15,7 +15,7 @@ public class LibraryIdentifierTest {
 		LibraryIdentifier testee = new LibraryIdentifier("testname;version=\"1.0.1-22\"");
 		assertEquals("testname", testee.getName());
 		assertEquals("1.0.1-22", testee.getVersion().toString());
-		assertEquals(22, testee.getVersion().getBuild());
+		assertEquals("22", testee.getVersion().getPreRelease());
 
 		testee = new LibraryIdentifier("testname-mit-strichen;version=\"1.0\"");
 		assertEquals("testname-mit-strichen", testee.getName());

--- a/core/src/test/java/i5/las2peer/classLoaders/libraries/LibraryVersionTest.java
+++ b/core/src/test/java/i5/las2peer/classLoaders/libraries/LibraryVersionTest.java
@@ -15,32 +15,32 @@ public class LibraryVersionTest {
 		LibraryVersion testee = new LibraryVersion("10.20.30-4010");
 		assertEquals(10, testee.getMajor());
 		assertEquals(20, testee.getMinor());
-		assertEquals(30, testee.getSub());
+		assertEquals(30, testee.getPatch());
 		assertEquals("4010", testee.getPreRelease());
 
 		testee = new LibraryVersion("10.20-4010");
 		assertEquals(10, testee.getMajor());
 		assertEquals(20, testee.getMinor());
-		assertEquals(0, testee.getSub());
+		assertEquals(0, testee.getPatch());
 		assertEquals("4010", testee.getPreRelease());
 
 		testee = new LibraryVersion("10.20");
 		assertEquals(10, testee.getMajor());
 		assertEquals(20, testee.getMinor());
-		assertEquals(0, testee.getSub());
+		assertEquals(0, testee.getPatch());
 		assertEquals("", testee.getBuild());
 		assertEquals("", testee.getPreRelease());
 
 		testee = new LibraryVersion("10-4010");
 		assertEquals(10, testee.getMajor());
 		assertEquals(0, testee.getMinor());
-		assertEquals(0, testee.getSub());
+		assertEquals(0, testee.getPatch());
 		assertEquals("4010", testee.getPreRelease());
 
 		testee = new LibraryVersion("10");
 		assertEquals(10, testee.getMajor());
 		assertEquals(0, testee.getMinor());
-		assertEquals(0, testee.getSub());
+		assertEquals(0, testee.getPatch());
 		assertEquals("", testee.getBuild());
 		assertEquals("", testee.getPreRelease());
 	}

--- a/core/src/test/java/i5/las2peer/classLoaders/libraries/LibraryVersionTest.java
+++ b/core/src/test/java/i5/las2peer/classLoaders/libraries/LibraryVersionTest.java
@@ -16,31 +16,33 @@ public class LibraryVersionTest {
 		assertEquals(10, testee.getMajor());
 		assertEquals(20, testee.getMinor());
 		assertEquals(30, testee.getSub());
-		assertEquals(4010, testee.getBuild());
+		assertEquals("4010", testee.getPreRelease());
 
 		testee = new LibraryVersion("10.20-4010");
 		assertEquals(10, testee.getMajor());
 		assertEquals(20, testee.getMinor());
 		assertEquals(0, testee.getSub());
-		assertEquals(4010, testee.getBuild());
+		assertEquals("4010", testee.getPreRelease());
 
 		testee = new LibraryVersion("10.20");
 		assertEquals(10, testee.getMajor());
 		assertEquals(20, testee.getMinor());
 		assertEquals(0, testee.getSub());
-		assertEquals(0, testee.getBuild());
+		assertEquals("", testee.getBuild());
+		assertEquals("", testee.getPreRelease());
 
 		testee = new LibraryVersion("10-4010");
 		assertEquals(10, testee.getMajor());
 		assertEquals(0, testee.getMinor());
 		assertEquals(0, testee.getSub());
-		assertEquals(4010, testee.getBuild());
+		assertEquals("4010", testee.getPreRelease());
 
 		testee = new LibraryVersion("10");
 		assertEquals(10, testee.getMajor());
 		assertEquals(0, testee.getMinor());
 		assertEquals(0, testee.getSub());
-		assertEquals(0, testee.getBuild());
+		assertEquals("", testee.getBuild());
+		assertEquals("", testee.getPreRelease());
 	}
 
 	@Test
@@ -77,12 +79,6 @@ public class LibraryVersionTest {
 		} catch (IllegalArgumentException e) {
 			// thats correct
 		}
-		try {
-			testee = new LibraryVersion("1.0-10.10");
-			fail("IllegalArgumentException should have been thrown");
-		} catch (IllegalArgumentException e) {
-			// thats correct
-		}
 	}
 
 	@Test
@@ -90,11 +86,11 @@ public class LibraryVersionTest {
 		// assertEquals ( new LibraryVersion ( "10.0.1-1234"), new LibraryVersion ( 10, 0, 1, 1234) );
 
 		LibraryVersion testee1 = new LibraryVersion("10.0.1-1234");
-		LibraryVersion testee2 = new LibraryVersion(10, 0, 1, 1234);
+		LibraryVersion testee2 = new LibraryVersion(10, 0, 1, "1234");
 		assertTrue(testee1.equals(testee2));
 		assertEquals(testee1, testee2);
 
-		assertFalse(new LibraryVersion("10.1.1-1234").equals(new LibraryVersion(10, 1, 1, 123)));
+		assertFalse(new LibraryVersion("10.1.1-1234").equals(new LibraryVersion(10, 1, 1, "123")));
 		assertFalse(new LibraryVersion("10.1.1-1234").equals(new LibraryVersion(10, 1, 1)));
 
 		// check for comparing against string versions
@@ -107,7 +103,7 @@ public class LibraryVersionTest {
 
 	@Test
 	public void testStringRepresentation() {
-		assertEquals("10.0.1-1234", new LibraryVersion(10, 0, 1, 1234).toString());
+		assertEquals("10.0.1-1234", new LibraryVersion(10, 0, 1, "1234").toString());
 		assertEquals("10.0-1234", new LibraryVersion("10.0-1234").toString());
 		assertEquals("10-1234", new LibraryVersion("10-1234").toString());
 		assertEquals("10.0.1", new LibraryVersion(10, 0, 1).toString());

--- a/core/src/test/java/i5/las2peer/p2p/ServiceVersionTest.java
+++ b/core/src/test/java/i5/las2peer/p2p/ServiceVersionTest.java
@@ -11,7 +11,7 @@ import org.junit.Test;
 import i5.las2peer.api.p2p.ServiceVersion;
 
 public class ServiceVersionTest {
-	ServiceVersion vNull, vStar, v0, v1, v1b, v10, v11, v100, v101, v1000, v1001;
+	ServiceVersion vNull, vStar, v0, v1, v1b, v10, v11, v100, v101, v1000, v1001, v100_alpha, v100_rc1, v100_pr_build, v100_build;
 
 	@Before
 	public void construct() {
@@ -26,6 +26,11 @@ public class ServiceVersionTest {
 		v101 = new ServiceVersion("1.0.1");
 		v1000 = new ServiceVersion("1.0.0-0");
 		v1001 = new ServiceVersion("1.0.0-1");
+
+		v100_alpha = new ServiceVersion("1.0.0-alpha");
+		v100_rc1 = new ServiceVersion("1.0.0-rc.1");
+		v100_pr_build = new ServiceVersion("1.0.0-rc.1+sha.0abcd");
+		v100_build = new ServiceVersion("1.0.0+sha.0abcd");
 	}
 
 	@Test
@@ -42,10 +47,13 @@ public class ServiceVersionTest {
 		assertTrue(v0.fits(vStar));
 		assertFalse(vStar.fits(v0));
 		assertTrue(v1000.fits(v100));
-		assertFalse(v100.fits(v1000));
+		assertTrue(v100.fits(v1000));
 		assertTrue(v1.fits(v1b));
 		assertTrue(v11.fits(v1));
 		assertTrue(vStar.fits(vStar));
+		assertTrue(v100.fits(v100_alpha));
+		assertTrue(v100.fits(v100_alpha));
+		assertTrue(v100.fits(v100_build));
 	}
 
 	@Test
@@ -55,12 +63,24 @@ public class ServiceVersionTest {
 		assertEquals(1, v1.compareTo(v0));
 		assertEquals(-1, v1.compareTo(v10));
 		assertEquals(-1, vNull.compareTo(v1));
+
+		// Release takes precedence over pre-release
+		assertEquals(1, v100.compareTo(v100_rc1));
+
+		// Higher pre-release takes precedence
+		assertEquals(-1, v1000.compareTo(v1001));
+		assertEquals(-1, v100_alpha.compareTo(v100_rc1));
+
+		// Build must be ignored in precedence
+		assertEquals(0, v100_rc1.compareTo(v100_pr_build));
+
 	}
 
 	@Test
 	public void testString() {
 		assertEquals("*", vStar.toString());
 		assertEquals("1.0.0-1", v1001.toString());
+		assertEquals("1.0.0-rc.1+sha.0abcd", v100_pr_build.toString());
 	}
 
 }

--- a/core/src/test/java/i5/las2peer/p2p/ServiceVersionTest.java
+++ b/core/src/test/java/i5/las2peer/p2p/ServiceVersionTest.java
@@ -11,7 +11,7 @@ import org.junit.Test;
 import i5.las2peer.api.p2p.ServiceVersion;
 
 public class ServiceVersionTest {
-	ServiceVersion vNull, vStar, v0, v1, v1b, v10, v11, v100, v101, v1000, v1001, v100_alpha, v100_rc1, v100_pr_build, v100_build;
+	ServiceVersion vNull, vStar, v0, v1, v1b, v10, v11, v100, v101, v1000, v1001, v100_alpha, v100_rc1, v100_rc2, v100_pr_build, v100_build;
 
 	@Before
 	public void construct() {
@@ -29,6 +29,7 @@ public class ServiceVersionTest {
 
 		v100_alpha = new ServiceVersion("1.0.0-alpha");
 		v100_rc1 = new ServiceVersion("1.0.0-rc.1");
+		v100_rc2 = new ServiceVersion("1.0.0-rc.2");
 		v100_pr_build = new ServiceVersion("1.0.0-rc.1+sha.0abcd");
 		v100_build = new ServiceVersion("1.0.0+sha.0abcd");
 	}
@@ -47,13 +48,15 @@ public class ServiceVersionTest {
 		assertTrue(v0.fits(vStar));
 		assertFalse(vStar.fits(v0));
 		assertTrue(v1000.fits(v100));
-		assertTrue(v100.fits(v1000));
+		assertFalse(v100.fits(v1000));
 		assertTrue(v1.fits(v1b));
 		assertTrue(v11.fits(v1));
 		assertTrue(vStar.fits(vStar));
-		assertTrue(v100.fits(v100_alpha));
-		assertTrue(v100.fits(v100_alpha));
+		assertFalse(v100.fits(v100_alpha));
+		assertTrue(v100_alpha.fits(v100));
+		assertFalse(v100.fits(v100_alpha));
 		assertTrue(v100.fits(v100_build));
+		assertFalse((v100_rc2.fits(v100_rc1)));
 	}
 
 	@Test

--- a/webconnector/frontend/package-lock.json
+++ b/webconnector/frontend/package-lock.json
@@ -1,0 +1,22882 @@
+{
+  "name": "las2peer-node-frontend",
+  "version": "2.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "las2peer-node-frontend",
+      "version": "2.0.0",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@cwmr/iron-star-rating": "^3.1.4",
+        "@polymer/app-layout": "^3.0.2",
+        "@polymer/app-route": "^3.0.2",
+        "@polymer/iron-ajax": "^3.0.1",
+        "@polymer/iron-collapse": "3.0.1",
+        "@polymer/iron-flex-layout": "^3.0.1",
+        "@polymer/iron-form": "^3.0.1",
+        "@polymer/iron-icon": "^3.0.1",
+        "@polymer/iron-icons": "^3.0.1",
+        "@polymer/iron-iconset-svg": "^3.0.1",
+        "@polymer/iron-input": "^3.0.1",
+        "@polymer/iron-media-query": "^3.0.1",
+        "@polymer/iron-pages": "^3.0.1",
+        "@polymer/iron-selector": "^3.0.1",
+        "@polymer/paper-button": "3.0.1",
+        "@polymer/paper-card": "^3.0.1",
+        "@polymer/paper-checkbox": "^3.0.1",
+        "@polymer/paper-dialog": "^3.0.1",
+        "@polymer/paper-dropdown-menu": "^3.0.1",
+        "@polymer/paper-icon-button": "^3.0.1",
+        "@polymer/paper-input": "^3.0.1",
+        "@polymer/paper-item": "^3.0.1",
+        "@polymer/paper-listbox": "^3.0.1",
+        "@polymer/paper-spinner": "^3.0.1",
+        "@polymer/paper-tabs": "^3.0.1",
+        "@polymer/paper-tooltip": "^3.0.1",
+        "@polymer/polymer": "^3.1.0",
+        "@webcomponents/webcomponentsjs": "^2.2.1",
+        "las2peer-frontend-statusbar": "github:rwth-acis/las2peer-frontend-statusbar#0.3.1"
+      },
+      "devDependencies": {
+        "polymer-cli": "^1.9.7",
+        "wct-browser-legacy": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/@cwmr/iron-star-rating": {
+      "version": "3.1.4",
+      "license": "MIT",
+      "dependencies": {
+        "@polymer/iron-icon": "^3.0.0",
+        "@polymer/iron-icons": "^3.0.0",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/app-layout": {
+      "version": "3.0.2",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
+        "@polymer/iron-media-query": "^3.0.0-pre.26",
+        "@polymer/iron-resizable-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-scroll-target-behavior": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/app-route": {
+      "version": "3.0.2",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/iron-location": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/font-roboto": {
+      "version": "3.0.2",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@polymer/iron-a11y-announcer": {
+      "version": "3.0.2",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/iron-a11y-keys-behavior": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/iron-ajax": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/iron-autogrow-textarea": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/iron-behaviors": "^3.0.0-pre.26",
+        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
+        "@polymer/iron-validatable-behavior": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/iron-behaviors": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/iron-checked-element-behavior": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/iron-form-element-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-validatable-behavior": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/iron-collapse": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/iron-resizable-behavior": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/iron-dropdown": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/iron-behaviors": "^3.0.0-pre.26",
+        "@polymer/iron-overlay-behavior": "^3.0.0-pre.27",
+        "@polymer/neon-animation": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/iron-fit-behavior": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/iron-flex-layout": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/iron-form": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/iron-ajax": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/iron-form-element-behavior": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/iron-icon": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
+        "@polymer/iron-meta": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/iron-icons": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/iron-icon": "^3.0.0-pre.26",
+        "@polymer/iron-iconset-svg": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/iron-iconset-svg": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/iron-meta": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/iron-image": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/iron-input": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/iron-a11y-announcer": "^3.0.0-pre.26",
+        "@polymer/iron-validatable-behavior": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/iron-list": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@polymer/iron-list/-/iron-list-3.1.0.tgz",
+      "integrity": "sha512-Eiv6xd3h3oPmn8SXFntXVfC3ZnegH+KHAxiKLKcOASFSRY3mHnr2AdcnExUJ9ItoCMA5UzKaM/0U22eWzGERtA==",
+      "dependencies": {
+        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-resizable-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-scroll-target-behavior": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/iron-location": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/iron-media-query": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/iron-menu-behavior": {
+      "version": "3.0.2",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
+        "@polymer/iron-selector": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/iron-meta": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/iron-overlay-behavior": {
+      "version": "3.0.2",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-fit-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-resizable-behavior": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/iron-pages": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/iron-resizable-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-selector": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/iron-resizable-behavior": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/iron-scroll-target-behavior": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/iron-selector": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/iron-validatable-behavior": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/iron-meta": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/lit-element": {
+      "version": "0.6.5",
+      "deprecated": "@polymer/lit-element has moved to lit-element. Please uninstall this package and install lit-element. See https://www.polymer-project.org/blog/2019-01-11-lit-element-rc",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "lit-html": "^1.0.0-rc.1"
+      }
+    },
+    "node_modules/@polymer/neon-animation": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/iron-resizable-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-selector": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/paper-badge": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@polymer/paper-badge/-/paper-badge-3.1.0.tgz",
+      "integrity": "sha512-5SH5Xw9ji16BjIZT2wY7oVgWX01fDyzm/nGnDi55iujPGsfaPV1itze7c9/3wlmgI+b28KBApUY9hW8f0h2V6g==",
+      "dependencies": {
+        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
+        "@polymer/iron-icon": "^3.0.0-pre.26",
+        "@polymer/iron-resizable-behavior": "^3.0.0-pre.26",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/paper-behaviors": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/iron-behaviors": "^3.0.0-pre.26",
+        "@polymer/iron-checked-element-behavior": "^3.0.0-pre.26",
+        "@polymer/paper-ripple": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/paper-button": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
+        "@polymer/paper-behaviors": "^3.0.0-pre.27",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/paper-card": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
+        "@polymer/iron-image": "^3.0.0-pre.26",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/paper-checkbox": {
+      "version": "3.1.0",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-checked-element-behavior": "^3.0.0-pre.26",
+        "@polymer/paper-behaviors": "^3.0.0-pre.27",
+        "@polymer/paper-ripple": "^3.0.0-pre.26",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/paper-dialog": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/iron-overlay-behavior": "^3.0.0-pre.27",
+        "@polymer/neon-animation": "^3.0.0-pre.26",
+        "@polymer/paper-dialog-behavior": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/paper-dialog-behavior": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/iron-overlay-behavior": "^3.0.0-pre.27",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/paper-dialog-scrollable": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/paper-dialog-scrollable/-/paper-dialog-scrollable-3.0.1.tgz",
+      "integrity": "sha512-1E8B9kNdL58jUrJ/BwqJeOoNVcxNrB559z//d1V0rVHWT5bWCCZegwS3G06iFK5MjxWFbIKzleVTLrT0opiZkA==",
+      "dependencies": {
+        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
+        "@polymer/paper-dialog-behavior": "^3.0.0-pre.26",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/paper-dropdown-menu": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-form-element-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-icon": "^3.0.0-pre.26",
+        "@polymer/iron-iconset-svg": "^3.0.0-pre.26",
+        "@polymer/iron-validatable-behavior": "^3.0.0-pre.26",
+        "@polymer/paper-behaviors": "^3.0.0-pre.27",
+        "@polymer/paper-input": "^3.0.0-pre.26",
+        "@polymer/paper-menu-button": "^3.0.0-pre.26",
+        "@polymer/paper-ripple": "^3.0.0-pre.26",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/paper-icon-button": {
+      "version": "3.0.2",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/iron-icon": "^3.0.0-pre.26",
+        "@polymer/paper-behaviors": "^3.0.0-pre.27",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/paper-input": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-autogrow-textarea": "^3.0.0-pre.26",
+        "@polymer/iron-behaviors": "^3.0.0-pre.26",
+        "@polymer/iron-form-element-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-input": "^3.0.0-pre.26",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/paper-item": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/iron-behaviors": "^3.0.0-pre.26",
+        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/paper-listbox": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/iron-behaviors": "^3.0.0-pre.26",
+        "@polymer/iron-menu-behavior": "^3.0.0-pre.26",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/paper-menu-button": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-behaviors": "^3.0.0-pre.26",
+        "@polymer/iron-dropdown": "^3.0.0-pre.26",
+        "@polymer/iron-fit-behavior": "^3.0.0-pre.26",
+        "@polymer/neon-animation": "^3.0.0-pre.26",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/paper-ripple": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/paper-spinner": {
+      "version": "3.0.2",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/paper-styles": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/font-roboto": "^3.0.1",
+        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/paper-tabs": {
+      "version": "3.1.0",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/iron-behaviors": "^3.0.0-pre.26",
+        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
+        "@polymer/iron-icon": "^3.0.0-pre.26",
+        "@polymer/iron-iconset-svg": "^3.0.0-pre.26",
+        "@polymer/iron-menu-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-resizable-behavior": "^3.0.0-pre.26",
+        "@polymer/paper-behaviors": "^3.0.0-pre.27",
+        "@polymer/paper-icon-button": "^3.0.0-pre.26",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/paper-toast": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/paper-toast/-/paper-toast-3.0.1.tgz",
+      "integrity": "sha512-pizuogzObniDdICUc6dSLrnDt2VzzoRne1gCmbD6sfOATVv5tc8UfrqhA2iHngbNBEbniBiciS3iogdp5KTVUQ==",
+      "dependencies": {
+        "@polymer/iron-a11y-announcer": "^3.0.0-pre.26",
+        "@polymer/iron-fit-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-overlay-behavior": "^3.0.0-pre.27",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/paper-toggle-button": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/paper-toggle-button/-/paper-toggle-button-3.0.1.tgz",
+      "integrity": "sha512-jadZB60fycT7YnSAH0H23LYo6/2HYmMZTtNr9LpdSIRFPLX6mqqxewex92cFz019bMKaRJgORn308hRlJo2u6A==",
+      "dependencies": {
+        "@polymer/iron-checked-element-behavior": "^3.0.0-pre.26",
+        "@polymer/paper-behaviors": "^3.0.0-pre.27",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/paper-tooltip": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "node_modules/@polymer/polymer": {
+      "version": "3.2.0",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@webcomponents/shadycss": "^1.8.0"
+      }
+    },
+    "node_modules/@polymer/sinonjs": {
+      "version": "1.17.1",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@polymer/test-fixture": {
+      "version": "3.0.0-pre.21",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@webcomponents/shadycss": {
+      "version": "1.9.0",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@webcomponents/webcomponentsjs": {
+      "version": "2.2.7",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/accessibility-developer-tools": {
+      "version": "2.12.0",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/async": {
+      "version": "1.5.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "optional": true,
+      "dependencies": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
+      }
+    },
+    "node_modules/babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "devOptional": true,
+      "dependencies": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      }
+    },
+    "node_modules/babel-runtime/node_modules/regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "devOptional": true
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/chai": {
+      "version": "3.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.0.1",
+        "deep-eql": "^0.1.3",
+        "type-detect": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "1.1.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/commander": {
+      "version": "2.9.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-readlink": ">= 1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6.x"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/core-js": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+      "deprecated": "core-js@<3.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
+      "devOptional": true,
+      "hasInstallScript": true
+    },
+    "node_modules/debug": {
+      "version": "2.6.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "0.1.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "0.1.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/deep-eql/node_modules/type-detect": {
+      "version": "0.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/diff": {
+      "version": "3.2.0",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/formatio": {
+      "version": "1.1.1",
+      "dev": true,
+      "dependencies": {
+        "samsam": "~1.1"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/glob": {
+      "version": "7.1.1",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.2",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/graceful-readlink": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/growl": {
+      "version": "1.9.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/has-ansi": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/json3": {
+      "version": "3.3.2",
+      "dev": true
+    },
+    "node_modules/jsrsasign": {
+      "version": "8.0.24",
+      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-8.0.24.tgz",
+      "integrity": "sha512-u45jAyusqUpyGbFc2IbHoeE4rSkoBWQgLe/w99temHenX+GyCz4nflU5sjK7ajU1ffZTezl6le7u43Yjr/lkQg==",
+      "funding": {
+        "url": "https://github.com/kjur/jsrsasign#donations"
+      }
+    },
+    "node_modules/las2peer-frontend-statusbar": {
+      "version": "0.3.1",
+      "resolved": "git+ssh://git@github.com/rwth-acis/las2peer-frontend-statusbar.git#b969a8d05c208e6702bf650e5d6b6b3b42980890",
+      "dependencies": {
+        "@polymer/lit-element": "^0.6.3",
+        "las2peer-frontend-user-widget": "github:rwth-acis/las2peer-frontend-user-widget#0.3.0",
+        "openidconnect-signin": "github:rwth-acis/openidconnect-signin"
+      }
+    },
+    "node_modules/las2peer-frontend-user-widget": {
+      "version": "0.3.0",
+      "resolved": "git+ssh://git@github.com/rwth-acis/las2peer-frontend-user-widget.git#63ad251f95b323938b78e0d68b14ec67a1a05511",
+      "dependencies": {
+        "@polymer/iron-ajax": "^3.0.1",
+        "@polymer/iron-dropdown": "^3.0.1",
+        "@polymer/iron-flex-layout": "^3.0.1",
+        "@polymer/iron-form": "^3.0.1",
+        "@polymer/iron-icon": "^3.0.1",
+        "@polymer/iron-icons": "^3.0.1",
+        "@polymer/iron-list": "^3.0.1",
+        "@polymer/paper-badge": "^3.0.1",
+        "@polymer/paper-button": "^3.0.1",
+        "@polymer/paper-card": "^3.0.1",
+        "@polymer/paper-dialog": "^3.0.1",
+        "@polymer/paper-dialog-scrollable": "^3.0.1",
+        "@polymer/paper-dropdown-menu": "^3.0.1",
+        "@polymer/paper-icon-button": "^3.0.1",
+        "@polymer/paper-input": "^3.0.1",
+        "@polymer/paper-item": "^3.0.1",
+        "@polymer/paper-spinner": "^3.0.1",
+        "@polymer/paper-styles": "^3.0.1",
+        "@polymer/paper-toast": "^3.0.1",
+        "@polymer/paper-toggle-button": "^3.0.1",
+        "@webcomponents/webcomponentsjs": "^2.2.1"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.5.1.tgz",
+      "integrity": "sha512-ogu7PiJTA33bEK0xGu1dmaX5vhcRjBXCFexPja0e7P7jqLhTpNKYRPmE+GmiCaRVAbiQKGkUgkh/i6+bh++dPQ==",
+      "dependencies": {
+        "lit-html": "^1.1.1"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "1.3.0",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/lodash": {
+      "version": "3.10.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash._baseassign": {
+      "version": "3.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
+      }
+    },
+    "node_modules/lodash._basecopy": {
+      "version": "3.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash._basecreate": {
+      "version": "3.0.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash._getnative": {
+      "version": "3.9.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash._isiterateecall": {
+      "version": "3.0.9",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.create": {
+      "version": "3.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basecreate": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
+      }
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarray": {
+      "version": "3.0.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.keys": {
+      "version": "3.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
+    },
+    "node_modules/lolex": {
+      "version": "1.3.2",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "0.0.8",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "0.0.8"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "3.5.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.8",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "he": "1.1.1",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha"
+      },
+      "engines": {
+        "node": ">= 0.10.x",
+        "npm": ">= 1.4.x"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/oidc-client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/oidc-client/-/oidc-client-1.6.1.tgz",
+      "integrity": "sha512-buA9G0hlFjUwxoL/xuHunBtTgoICtJSojnZtATqMliUTKxPYAzHprOQ85Lj0hgF+Zv8lI/ViqaNFDG0Z5KCUKA==",
+      "dependencies": {
+        "jsrsasign": "^8.0.12"
+      },
+      "optionalDependencies": {
+        "babel-polyfill": ">=6.9.1"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/openidconnect-signin": {
+      "version": "2.1.1",
+      "resolved": "git+ssh://git@github.com/rwth-acis/openidconnect-signin.git#e9167a965acacfa3e686eb6d78a59e4b863939b4",
+      "license": "MIT",
+      "dependencies": {
+        "lit-element": "^2.0.0",
+        "oidc-client": "1.6.1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli": {
+      "version": "1.9.7",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@octokit/rest": "^16.2.0",
+        "@types/chalk": "^0.4.31",
+        "@types/del": "^3.0.0",
+        "@types/findup-sync": "^0.3.29",
+        "@types/globby": "^6.1.0",
+        "@types/inquirer": "0.0.32",
+        "@types/merge-stream": "^1.0.28",
+        "@types/mz": "^0.0.31",
+        "@types/request": "2.0.3",
+        "@types/resolve": "0.0.4",
+        "@types/rimraf": "^0.0.28",
+        "@types/semver": "^5.3.30",
+        "@types/temp": "^0.8.28",
+        "@types/update-notifier": "^1.0.0",
+        "@types/vinyl": "^2.0.0",
+        "@types/vinyl-fs": "0.0.28",
+        "@types/yeoman-generator": "^2.0.3",
+        "bower": "^1.8.2",
+        "bower-json": "^0.8.1",
+        "bower-logger": "^0.2.2",
+        "chalk": "^1.1.3",
+        "chokidar": "^1.7.0",
+        "command-line-args": "^5.0.2",
+        "command-line-commands": "^2.0.1",
+        "command-line-usage": "^5.0.5",
+        "del": "^3.0.0",
+        "findup-sync": "^0.4.2",
+        "globby": "^8.0.1",
+        "gunzip-maybe": "^1.3.1",
+        "inquirer": "^1.0.2",
+        "merge-stream": "^1.0.1",
+        "mz": "^2.6.0",
+        "plylog": "^1.0.0",
+        "polymer-analyzer": "^3.2.2",
+        "polymer-build": "^3.1.2",
+        "polymer-bundler": "^4.0.9",
+        "polymer-linter": "^3.0.0",
+        "polymer-project-config": "^4.0.3",
+        "polyserve": "^0.27.15",
+        "request": "^2.72.0",
+        "rimraf": "^2.6.1",
+        "semver": "^5.3.0",
+        "tar-fs": "^1.12.0",
+        "temp": "^0.8.3",
+        "update-notifier": "^1.0.0",
+        "validate-element-name": "^2.1.1",
+        "vinyl": "^1.1.1",
+        "vinyl-fs": "^2.4.3",
+        "web-component-tester": "^6.9.0",
+        "yeoman-environment": "^1.5.2",
+        "yeoman-generator": "^3.1.1"
+      },
+      "bin": {
+        "polymer": "bin/polymer.js"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/code-frame": {
+      "version": "7.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/core": {
+      "version": "7.3.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/generator": "^7.3.4",
+        "@babel/helpers": "^7.2.0",
+        "@babel/parser": "^7.3.4",
+        "@babel/template": "^7.2.2",
+        "@babel/traverse": "^7.3.4",
+        "@babel/types": "^7.3.4",
+        "convert-source-map": "^1.1.0",
+        "debug": "^4.1.0",
+        "json5": "^2.1.0",
+        "lodash": "^4.17.11",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/core/node_modules/debug": {
+      "version": "4.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/core/node_modules/ms": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/@babel/generator": {
+      "version": "7.3.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.3.4",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.11",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/helper-builder-binary-assignment-operator-visitor": {
+      "version": "7.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-explode-assignable-expression": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/helper-call-delegate": {
+      "version": "7.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-hoist-variables": "^7.0.0",
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/helper-define-map": {
+      "version": "7.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/types": "^7.0.0",
+        "lodash": "^4.17.10"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/helper-explode-assignable-expression": {
+      "version": "7.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/helper-function-name": {
+      "version": "7.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/helper-get-function-arity": {
+      "version": "7.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/helper-hoist-variables": {
+      "version": "7.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/helper-module-imports": {
+      "version": "7.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/helper-module-transforms": {
+      "version": "7.2.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-simple-access": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.0.0",
+        "@babel/template": "^7.2.2",
+        "@babel/types": "^7.2.2",
+        "lodash": "^4.17.10"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/helper-plugin-utils": {
+      "version": "7.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/@babel/helper-regex": {
+      "version": "7.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.10"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/helper-remap-async-to-generator": {
+      "version": "7.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.0.0",
+        "@babel/helper-wrap-function": "^7.1.0",
+        "@babel/template": "^7.1.0",
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/helper-replace-supers": {
+      "version": "7.3.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.0.0",
+        "@babel/helper-optimise-call-expression": "^7.0.0",
+        "@babel/traverse": "^7.3.4",
+        "@babel/types": "^7.3.4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/helper-simple-access": {
+      "version": "7.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/helper-split-export-declaration": {
+      "version": "7.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/helper-wrap-function": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/template": "^7.1.0",
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.2.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/helpers": {
+      "version": "7.3.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.1.2",
+        "@babel/traverse": "^7.1.5",
+        "@babel/types": "^7.3.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/highlight": {
+      "version": "7.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/highlight/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/highlight/node_modules/chalk": {
+      "version": "2.4.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/highlight/node_modules/supports-color": {
+      "version": "5.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/parser": {
+      "version": "7.3.4",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/plugin-external-helpers": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/plugin-proposal-async-generator-functions": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-remap-async-to-generator": "^7.1.0",
+        "@babel/plugin-syntax-async-generators": "^7.2.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/plugin-proposal-object-rest-spread": {
+      "version": "7.3.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.2.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/plugin-syntax-dynamic-import": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/plugin-transform-arrow-functions": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/plugin-transform-async-to-generator": {
+      "version": "7.3.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-remap-async-to-generator": "^7.1.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/plugin-transform-block-scoping": {
+      "version": "7.3.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "lodash": "^4.17.11"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/plugin-transform-classes": {
+      "version": "7.3.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.0.0",
+        "@babel/helper-define-map": "^7.1.0",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-optimise-call-expression": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.3.4",
+        "@babel/helper-split-export-declaration": "^7.0.0",
+        "globals": "^11.1.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/plugin-transform-computed-properties": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/plugin-transform-destructuring": {
+      "version": "7.3.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/plugin-transform-duplicate-keys": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/plugin-transform-for-of": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/plugin-transform-function-name": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/plugin-transform-instanceof": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/plugin-transform-literals": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/plugin-transform-modules-amd": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/plugin-transform-object-super": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.1.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/plugin-transform-parameters": {
+      "version": "7.3.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-call-delegate": "^7.1.0",
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/plugin-transform-regenerator": {
+      "version": "7.3.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regenerator-transform": "^0.13.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/plugin-transform-shorthand-properties": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/plugin-transform-spread": {
+      "version": "7.2.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/plugin-transform-sticky-regex": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-regex": "^7.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/plugin-transform-template-literals": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/plugin-transform-typeof-symbol": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/plugin-transform-unicode-regex": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-regex": "^7.0.0",
+        "regexpu-core": "^4.1.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/template": {
+      "version": "7.2.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.2.2",
+        "@babel/types": "^7.2.2"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/traverse": {
+      "version": "7.3.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/generator": "^7.3.4",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.0.0",
+        "@babel/parser": "^7.3.4",
+        "@babel/types": "^7.3.4",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.11"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/traverse/node_modules/debug": {
+      "version": "4.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@babel/traverse/node_modules/ms": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/@babel/types": {
+      "version": "7.3.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.11",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@mrmlnc/readdir-enhanced": {
+      "version": "2.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-me-maybe": "^1.0.1",
+        "glob-to-regexp": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@nodelib/fs.stat": {
+      "version": "1.1.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@octokit/endpoint": {
+      "version": "3.1.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "3.2.0",
+        "is-plain-object": "^2.0.4",
+        "universal-user-agent": "^2.0.1",
+        "url-template": "^2.0.8"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@octokit/request": {
+      "version": "2.4.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^3.1.1",
+        "is-plain-object": "^2.0.4",
+        "node-fetch": "^2.3.0",
+        "universal-user-agent": "^2.0.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@octokit/rest": {
+      "version": "16.16.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "2.4.0",
+        "before-after-hook": "^1.2.0",
+        "btoa-lite": "^1.0.0",
+        "lodash.get": "^4.4.2",
+        "lodash.set": "^4.3.2",
+        "lodash.uniq": "^4.5.0",
+        "octokit-pagination-methods": "^1.1.0",
+        "universal-user-agent": "^2.0.0",
+        "url-template": "^2.0.8"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@polymer/esm-amd-loader": {
+      "version": "1.0.4",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/polymer-cli/node_modules/@polymer/sinonjs": {
+      "version": "1.17.1",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/polymer-cli/node_modules/@polymer/test-fixture": {
+      "version": "0.0.3",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/polymer-cli/node_modules/@types/babel-generator": {
+      "version": "6.25.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/babel-types": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/babel-traverse": {
+      "version": "6.25.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/babel-types": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/babel-types": {
+      "version": "6.25.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/@types/babylon": {
+      "version": "6.16.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/babel-types": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/bluebird": {
+      "version": "3.5.26",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/@types/body-parser": {
+      "version": "1.17.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/chai": {
+      "version": "4.1.7",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/@types/chai-subset": {
+      "version": "1.3.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/chalk": {
+      "version": "0.4.31",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/@types/clean-css": {
+      "version": "4.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/clone": {
+      "version": "0.1.30",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/@types/compression": {
+      "version": "0.0.33",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/connect": {
+      "version": "3.4.32",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/content-type": {
+      "version": "1.1.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/@types/cssbeautify": {
+      "version": "0.3.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/@types/del": {
+      "version": "3.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/glob": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/doctrine": {
+      "version": "0.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/@types/escape-html": {
+      "version": "0.0.20",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/@types/estree": {
+      "version": "0.0.39",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/@types/events": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/@types/express": {
+      "version": "4.16.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/express-serve-static-core": {
+      "version": "4.16.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/range-parser": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/fast-levenshtein": {
+      "version": "0.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/@types/findup-sync": {
+      "version": "0.3.30",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/minimatch": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/form-data": {
+      "version": "2.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/freeport": {
+      "version": "1.0.21",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/polymer-cli/node_modules/@types/glob": {
+      "version": "7.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/glob-stream": {
+      "version": "6.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/glob": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/globby": {
+      "version": "6.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/glob": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/gulp-if": {
+      "version": "0.0.33",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/vinyl": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/html-minifier": {
+      "version": "3.5.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/clean-css": "*",
+        "@types/relateurl": "*",
+        "@types/uglify-js": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/inquirer": {
+      "version": "0.0.32",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/rx": "*",
+        "@types/through": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/is-windows": {
+      "version": "0.2.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/@types/launchpad": {
+      "version": "0.6.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/polymer-cli/node_modules/@types/merge-stream": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/mime": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/@types/minimatch": {
+      "version": "3.0.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/@types/mz": {
+      "version": "0.0.31",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/node": {
+      "version": "11.10.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/@types/opn": {
+      "version": "3.0.28",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/parse5": {
+      "version": "2.2.34",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/path-is-inside": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/@types/pem": {
+      "version": "1.9.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/range-parser": {
+      "version": "1.2.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/@types/relateurl": {
+      "version": "0.2.28",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/@types/request": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/form-data": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/resolve": {
+      "version": "0.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/rimraf": {
+      "version": "0.0.28",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/@types/rx": {
+      "version": "4.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/rx-core": "*",
+        "@types/rx-core-binding": "*",
+        "@types/rx-lite": "*",
+        "@types/rx-lite-aggregates": "*",
+        "@types/rx-lite-async": "*",
+        "@types/rx-lite-backpressure": "*",
+        "@types/rx-lite-coincidence": "*",
+        "@types/rx-lite-experimental": "*",
+        "@types/rx-lite-joinpatterns": "*",
+        "@types/rx-lite-testing": "*",
+        "@types/rx-lite-time": "*",
+        "@types/rx-lite-virtualtime": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/rx-core": {
+      "version": "4.0.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/@types/rx-core-binding": {
+      "version": "4.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/rx-core": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/rx-lite": {
+      "version": "4.0.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/rx-core": "*",
+        "@types/rx-core-binding": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/rx-lite-aggregates": {
+      "version": "4.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/rx-lite": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/rx-lite-async": {
+      "version": "4.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/rx-lite": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/rx-lite-backpressure": {
+      "version": "4.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/rx-lite": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/rx-lite-coincidence": {
+      "version": "4.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/rx-lite": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/rx-lite-experimental": {
+      "version": "4.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/rx-lite": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/rx-lite-joinpatterns": {
+      "version": "4.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/rx-lite": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/rx-lite-testing": {
+      "version": "4.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/rx-lite-virtualtime": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/rx-lite-time": {
+      "version": "4.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/rx-lite": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/rx-lite-virtualtime": {
+      "version": "4.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/rx-lite": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/semver": {
+      "version": "5.5.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/@types/serve-static": {
+      "version": "1.13.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express-serve-static-core": "*",
+        "@types/mime": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/spdy": {
+      "version": "3.4.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/temp": {
+      "version": "0.8.33",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/through": {
+      "version": "0.0.29",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/ua-parser-js": {
+      "version": "0.7.32",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/@types/uglify-js": {
+      "version": "3.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/uglify-js/node_modules/source-map": {
+      "version": "0.6.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/update-notifier": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/@types/uuid": {
+      "version": "3.4.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/vinyl": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/vinyl-fs": {
+      "version": "0.0.28",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/glob-stream": "*",
+        "@types/node": "*",
+        "@types/vinyl": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/whatwg-url": {
+      "version": "6.4.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@types/which": {
+      "version": "1.3.1",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/polymer-cli/node_modules/@types/yeoman-generator": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/events": "*",
+        "@types/inquirer": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/@webcomponents/webcomponentsjs": {
+      "version": "1.3.3",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/polymer-cli/node_modules/accepts": {
+      "version": "1.3.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.18",
+        "negotiator": "0.6.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/accessibility-developer-tools": {
+      "version": "2.12.0",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/polymer-cli/node_modules/acorn": {
+      "version": "5.7.3",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/acorn-jsx": {
+      "version": "3.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^3.0.4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/acorn-jsx/node_modules/acorn": {
+      "version": "3.3.0",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/adm-zip": {
+      "version": "0.4.13",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.3.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/after": {
+      "version": "0.8.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/agent-base": {
+      "version": "4.2.1",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es6-promisify": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/agent-base/node_modules/es6-promisify": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es6-promise": "^4.0.3"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/ajv": {
+      "version": "6.9.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/ansi-align": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^2.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/ansi-align/node_modules/ansi-regex": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/ansi-align/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/ansi-align/node_modules/string-width": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/ansi-align/node_modules/strip-ansi": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/ansi-escapes": {
+      "version": "1.4.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/any-promise": {
+      "version": "1.3.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/anymatch": {
+      "version": "1.3.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "micromatch": "^2.1.5",
+        "normalize-path": "^2.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/append-field": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/archiver": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^1.3.0",
+        "async": "^2.0.0",
+        "buffer-crc32": "^0.2.1",
+        "glob": "^7.0.0",
+        "lodash": "^4.8.0",
+        "readable-stream": "^2.0.0",
+        "tar-stream": "^1.5.0",
+        "zip-stream": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/archiver-utils": {
+      "version": "1.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.0.0",
+        "graceful-fs": "^4.1.0",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.8.0",
+        "normalize-path": "^2.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/argv-tools": {
+      "version": "0.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^2.0.0",
+        "find-replace": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/arr-diff": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arr-flatten": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/arr-flatten": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/arr-union": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/array-back": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "typical": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/array-differ": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/array-find-index": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/array-flatten": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/array-union": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-uniq": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/array-uniq": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/array-unique": {
+      "version": "0.2.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/arraybuffer.slice": {
+      "version": "0.0.7",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/arrify": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/asn1": {
+      "version": "0.2.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/assert-plus": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/assign-symbols": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/async": {
+      "version": "2.6.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.11"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/async-each": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/async-limiter": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/asynckit": {
+      "version": "0.4.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/atob": {
+      "version": "2.1.2",
+      "dev": true,
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/aws-sign2": {
+      "version": "0.7.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/aws4": {
+      "version": "1.8.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/babel-code-frame": {
+      "version": "6.26.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/babel-code-frame/node_modules/js-tokens": {
+      "version": "3.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/babel-generator": {
+      "version": "6.26.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.7",
+        "trim-right": "^1.0.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/babel-generator/node_modules/jsesc": {
+      "version": "1.3.0",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/babel-helper-evaluate-path": {
+      "version": "0.4.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/babel-helper-flip-expressions": {
+      "version": "0.4.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/babel-helper-is-nodes-equiv": {
+      "version": "0.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/babel-helper-is-void-0": {
+      "version": "0.4.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/babel-helper-mark-eval-scopes": {
+      "version": "0.4.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/babel-helper-remove-or-void": {
+      "version": "0.4.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/babel-helper-to-multiple-sequence-expressions": {
+      "version": "0.4.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/babel-messages": {
+      "version": "6.23.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/babel-plugin-minify-builtins": {
+      "version": "0.4.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-helper-evaluate-path": "^0.4.3"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/babel-plugin-minify-constant-folding": {
+      "version": "0.4.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-helper-evaluate-path": "^0.4.3"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/babel-plugin-minify-dead-code-elimination": {
+      "version": "0.4.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-helper-evaluate-path": "^0.4.3",
+        "babel-helper-mark-eval-scopes": "^0.4.3",
+        "babel-helper-remove-or-void": "^0.4.3",
+        "lodash.some": "^4.6.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/babel-plugin-minify-flip-comparisons": {
+      "version": "0.4.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-helper-is-void-0": "^0.4.3"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/babel-plugin-minify-guarded-expressions": {
+      "version": "0.4.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-helper-flip-expressions": "^0.4.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/babel-plugin-minify-infinity": {
+      "version": "0.4.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/babel-plugin-minify-mangle-names": {
+      "version": "0.4.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-helper-mark-eval-scopes": "^0.4.3"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/babel-plugin-minify-numeric-literals": {
+      "version": "0.4.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/babel-plugin-minify-replace": {
+      "version": "0.4.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/babel-plugin-minify-simplify": {
+      "version": "0.4.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-helper-flip-expressions": "^0.4.3",
+        "babel-helper-is-nodes-equiv": "^0.0.1",
+        "babel-helper-to-multiple-sequence-expressions": "^0.4.3"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/babel-plugin-minify-type-constructors": {
+      "version": "0.4.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-helper-is-void-0": "^0.4.3"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/babel-plugin-transform-inline-consecutive-adds": {
+      "version": "0.4.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/babel-plugin-transform-member-expression-literals": {
+      "version": "6.10.0-alpha.f95869d4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/babel-plugin-transform-merge-sibling-variables": {
+      "version": "6.10.0-alpha.f95869d4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/babel-plugin-transform-minify-booleans": {
+      "version": "6.10.0-alpha.f95869d4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/babel-plugin-transform-property-literals": {
+      "version": "6.10.0-alpha.f95869d4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/babel-plugin-transform-regexp-constructors": {
+      "version": "0.4.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/babel-plugin-transform-remove-console": {
+      "version": "6.10.0-alpha.f95869d4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/babel-plugin-transform-remove-debugger": {
+      "version": "6.10.0-alpha.f95869d4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/babel-plugin-transform-remove-undefined": {
+      "version": "0.4.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-helper-evaluate-path": "^0.4.3"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/babel-plugin-transform-simplify-comparison-operators": {
+      "version": "6.10.0-alpha.f95869d4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/babel-plugin-transform-undefined-to-void": {
+      "version": "6.10.0-alpha.f95869d4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/babel-preset-minify": {
+      "version": "0.4.0-alpha.caaefb4c",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-minify-builtins": "^0.4.0-alpha.caaefb4c",
+        "babel-plugin-minify-constant-folding": "^0.4.0-alpha.caaefb4c",
+        "babel-plugin-minify-dead-code-elimination": "^0.4.0-alpha.caaefb4c",
+        "babel-plugin-minify-flip-comparisons": "^0.4.0-alpha.caaefb4c",
+        "babel-plugin-minify-guarded-expressions": "^0.4.0-alpha.caaefb4c",
+        "babel-plugin-minify-infinity": "^0.4.0-alpha.caaefb4c",
+        "babel-plugin-minify-mangle-names": "^0.4.0-alpha.caaefb4c",
+        "babel-plugin-minify-numeric-literals": "^0.4.0-alpha.caaefb4c",
+        "babel-plugin-minify-replace": "^0.4.0-alpha.caaefb4c",
+        "babel-plugin-minify-simplify": "^0.4.0-alpha.caaefb4c",
+        "babel-plugin-minify-type-constructors": "^0.4.0-alpha.caaefb4c",
+        "babel-plugin-transform-inline-consecutive-adds": "^0.4.0-alpha.caaefb4c",
+        "babel-plugin-transform-member-expression-literals": "^6.10.0-alpha.caaefb4c",
+        "babel-plugin-transform-merge-sibling-variables": "^6.10.0-alpha.caaefb4c",
+        "babel-plugin-transform-minify-booleans": "^6.10.0-alpha.caaefb4c",
+        "babel-plugin-transform-property-literals": "^6.10.0-alpha.caaefb4c",
+        "babel-plugin-transform-regexp-constructors": "^0.4.0-alpha.caaefb4c",
+        "babel-plugin-transform-remove-console": "^6.10.0-alpha.caaefb4c",
+        "babel-plugin-transform-remove-debugger": "^6.10.0-alpha.caaefb4c",
+        "babel-plugin-transform-remove-undefined": "^0.4.0-alpha.caaefb4c",
+        "babel-plugin-transform-simplify-comparison-operators": "^6.10.0-alpha.caaefb4c",
+        "babel-plugin-transform-undefined-to-void": "^6.10.0-alpha.caaefb4c",
+        "lodash.isplainobject": "^4.0.6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/babel-traverse": {
+      "version": "6.26.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/babel-traverse/node_modules/babylon": {
+      "version": "6.18.0",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "babylon": "bin/babylon.js"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/babel-traverse/node_modules/globals": {
+      "version": "9.18.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/babel-types": {
+      "version": "6.26.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/babel-types/node_modules/to-fast-properties": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/babylon": {
+      "version": "7.0.0-beta.47",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "babylon": "bin/babylon.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/backo2": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/balanced-match": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/base": {
+      "version": "0.11.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/base/node_modules/define-property": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/base/node_modules/is-accessor-descriptor": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/base/node_modules/is-data-descriptor": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/base/node_modules/is-descriptor": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-accessor-descriptor": "^1.0.0",
+        "is-data-descriptor": "^1.0.0",
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/base/node_modules/kind-of": {
+      "version": "6.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/base64-arraybuffer": {
+      "version": "0.1.5",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/base64-js": {
+      "version": "1.2.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/base64id": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/before-after-hook": {
+      "version": "1.3.2",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/polymer-cli/node_modules/better-assert": {
+      "version": "1.0.2",
+      "dev": true,
+      "dependencies": {
+        "callsite": "1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/binary-extensions": {
+      "version": "1.13.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/binaryextensions": {
+      "version": "2.1.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/bl": {
+      "version": "1.2.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/blob": {
+      "version": "0.0.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/body-parser": {
+      "version": "1.18.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.0.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "~1.6.3",
+        "iconv-lite": "0.4.23",
+        "on-finished": "~2.3.0",
+        "qs": "6.5.2",
+        "raw-body": "2.3.3",
+        "type-is": "~1.6.16"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/bower": {
+      "version": "1.8.8",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "bower": "bin/bower"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/bower-config": {
+      "version": "1.4.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.3",
+        "mout": "^1.0.0",
+        "optimist": "^0.6.1",
+        "osenv": "^0.1.3",
+        "untildify": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/bower-json": {
+      "version": "0.8.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-extend": "^0.4.0",
+        "ext-name": "^3.0.0",
+        "graceful-fs": "^4.1.3",
+        "intersect": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/bower-logger": {
+      "version": "0.2.2",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/boxen": {
+      "version": "1.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-align": "^2.0.0",
+        "camelcase": "^4.0.0",
+        "chalk": "^2.0.1",
+        "cli-boxes": "^1.0.0",
+        "string-width": "^2.0.0",
+        "term-size": "^1.2.0",
+        "widest-line": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/boxen/node_modules/ansi-regex": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/boxen/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/boxen/node_modules/camelcase": {
+      "version": "4.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/boxen/node_modules/chalk": {
+      "version": "2.4.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/boxen/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/boxen/node_modules/string-width": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/boxen/node_modules/strip-ansi": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/boxen/node_modules/supports-color": {
+      "version": "5.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/braces": {
+      "version": "1.8.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/browser-capabilities": {
+      "version": "1.1.3",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/ua-parser-js": "^0.7.31",
+        "ua-parser-js": "^0.7.15"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/browserify-zlib": {
+      "version": "0.1.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~0.2.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/browserstack": {
+      "version": "1.5.2",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "https-proxy-agent": "^2.2.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/btoa-lite": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/buffer": {
+      "version": "5.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/buffer-alloc": {
+      "version": "1.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/buffer-fill": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/buffer-from": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/busboy": {
+      "version": "0.2.14",
+      "dev": true,
+      "dependencies": {
+        "dicer": "0.2.5",
+        "readable-stream": "1.1.x"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/busboy/node_modules/isarray": {
+      "version": "0.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/busboy/node_modules/readable-stream": {
+      "version": "1.1.14",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/busboy/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/bytes": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/cache-base": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/call-me-maybe": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/callsite": {
+      "version": "1.0.0",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/camel-case": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/camelcase": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/camelcase-keys": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/cancel-token": {
+      "version": "0.1.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/node": "^4.0.30"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/cancel-token/node_modules/@types/node": {
+      "version": "4.9.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/capture-stack-trace": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/caseless": {
+      "version": "0.12.0",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/polymer-cli/node_modules/chalk": {
+      "version": "1.1.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/chardet": {
+      "version": "0.7.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/charenc": {
+      "version": "0.0.2",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/chokidar": {
+      "version": "1.7.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "^1.3.0",
+        "async-each": "^1.0.0",
+        "glob-parent": "^2.0.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^2.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^1.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/chownr": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/polymer-cli/node_modules/ci-info": {
+      "version": "1.6.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/class-utils": {
+      "version": "0.3.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/class-utils/node_modules/define-property": {
+      "version": "0.2.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/clean-css": {
+      "version": "4.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "source-map": "~0.6.0"
+      },
+      "engines": {
+        "node": ">= 4.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/clean-css/node_modules/source-map": {
+      "version": "0.6.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/cleankill": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/polymer-cli/node_modules/cli-boxes": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/cli-cursor": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/cli-table": {
+      "version": "0.3.1",
+      "dev": true,
+      "dependencies": {
+        "colors": "1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.2.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/cli-table/node_modules/colors": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/cli-width": {
+      "version": "2.2.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/polymer-cli/node_modules/clone": {
+      "version": "2.1.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/clone-buffer": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/clone-stats": {
+      "version": "0.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/cloneable-readable": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "process-nextick-args": "^2.0.0",
+        "readable-stream": "^2.3.5"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/code-point-at": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/collection-visit": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/color": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/color-convert": {
+      "version": "1.9.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/color-name": {
+      "version": "1.1.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/color-string": {
+      "version": "1.5.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/colornames": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/colors": {
+      "version": "1.3.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/colorspace": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color": "3.0.x",
+        "text-hex": "1.0.x"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/combined-stream": {
+      "version": "1.0.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/command-line-args": {
+      "version": "5.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argv-tools": "^0.1.1",
+        "array-back": "^2.0.0",
+        "find-replace": "^2.0.1",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/command-line-commands": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/command-line-usage": {
+      "version": "5.0.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^2.0.0",
+        "chalk": "^2.4.1",
+        "table-layout": "^0.4.3",
+        "typical": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/command-line-usage/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/command-line-usage/node_modules/chalk": {
+      "version": "2.4.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/command-line-usage/node_modules/supports-color": {
+      "version": "5.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/commander": {
+      "version": "2.17.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/commondir": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/component-bind": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "node_modules/polymer-cli/node_modules/component-emitter": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/component-inherit": {
+      "version": "0.0.3",
+      "dev": true
+    },
+    "node_modules/polymer-cli/node_modules/compress-commons": {
+      "version": "1.2.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "^0.2.1",
+        "crc32-stream": "^2.0.0",
+        "normalize-path": "^2.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/compressible": {
+      "version": "2.0.16",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.38.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/compression": {
+      "version": "1.7.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.5",
+        "bytes": "3.0.0",
+        "compressible": "~2.0.14",
+        "debug": "2.6.9",
+        "on-headers": "~1.0.1",
+        "safe-buffer": "5.1.2",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/concat-map": {
+      "version": "0.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/concat-stream": {
+      "version": "1.6.2",
+      "dev": true,
+      "engines": [
+        "node >= 0.8"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/configstore": {
+      "version": "3.1.2",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dot-prop": "^4.1.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "unique-string": "^1.0.0",
+        "write-file-atomic": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/content-disposition": {
+      "version": "0.5.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/content-type": {
+      "version": "1.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/convert-source-map": {
+      "version": "1.6.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/cookie": {
+      "version": "0.3.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/copy-descriptor": {
+      "version": "0.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/core-util-is": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/cors": {
+      "version": "2.8.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/crc": {
+      "version": "3.8.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.1.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/crc32-stream": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc": "^3.4.4",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/create-error-class": {
+      "version": "3.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "capture-stack-trace": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/cross-spawn": {
+      "version": "6.0.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/crypt": {
+      "version": "0.0.2",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/crypto-random-string": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/css-slam": {
+      "version": "2.1.2",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "command-line-args": "^5.0.2",
+        "command-line-usage": "^5.0.5",
+        "dom5": "^3.0.0",
+        "parse5": "^4.0.0",
+        "shady-css-parser": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/css-what": {
+      "version": "2.1.3",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/cssbeautify": {
+      "version": "0.3.1",
+      "dev": true,
+      "bin": {
+        "cssbeautify": "bin/cssbeautify"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/currently-unhandled": {
+      "version": "0.4.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-find-index": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/dargs": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/dashdash": {
+      "version": "1.14.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/dateformat": {
+      "version": "3.0.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/debug": {
+      "version": "2.6.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/decamelize": {
+      "version": "1.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/decode-uri-component": {
+      "version": "0.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/decompress-response": {
+      "version": "3.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/deep-extend": {
+      "version": "0.4.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/deepmerge": {
+      "version": "3.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/define-property": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/define-property/node_modules/is-accessor-descriptor": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/define-property/node_modules/is-data-descriptor": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/define-property/node_modules/is-descriptor": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-accessor-descriptor": "^1.0.0",
+        "is-data-descriptor": "^1.0.0",
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/define-property/node_modules/kind-of": {
+      "version": "6.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/del": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "globby": "^6.1.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "p-map": "^1.1.1",
+        "pify": "^3.0.0",
+        "rimraf": "^2.2.8"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/del/node_modules/globby": {
+      "version": "6.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^1.0.1",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/del/node_modules/globby/node_modules/pify": {
+      "version": "2.3.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/del/node_modules/pify": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/depd": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/destroy": {
+      "version": "1.0.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/detect-conflict": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/detect-file": {
+      "version": "0.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fs-exists-sync": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/detect-indent": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "repeating": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/detect-node": {
+      "version": "2.0.4",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/polymer-cli/node_modules/diagnostics": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colorspace": "1.1.x",
+        "enabled": "1.0.x",
+        "kuler": "1.0.x"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/dicer": {
+      "version": "0.2.5",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "1.1.x",
+        "streamsearch": "0.1.2"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/dicer/node_modules/isarray": {
+      "version": "0.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/dicer/node_modules/readable-stream": {
+      "version": "1.1.14",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/dicer/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/diff": {
+      "version": "3.5.0",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/dir-glob": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arrify": "^1.0.1",
+        "path-type": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/dir-glob/node_modules/path-type": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/dir-glob/node_modules/pify": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/doctrine": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/dom-urls": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "urijs": "^1.16.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/dom5": {
+      "version": "3.0.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/parse5": "^2.2.34",
+        "clone": "^2.1.0",
+        "parse5": "^4.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/dot-prop": {
+      "version": "4.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-obj": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/duplexer2": {
+      "version": "0.1.4",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/duplexer3": {
+      "version": "0.1.4",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/polymer-cli/node_modules/duplexify": {
+      "version": "3.7.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/ecc-jsbn": {
+      "version": "0.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/editions": {
+      "version": "2.1.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "errlop": "^1.1.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/ee-first": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/ejs": {
+      "version": "2.6.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/emitter-component": {
+      "version": "1.1.1",
+      "dev": true
+    },
+    "node_modules/polymer-cli/node_modules/enabled": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-variable": "0.0.x"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/end-of-stream": {
+      "version": "1.4.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/ends-with": {
+      "version": "0.2.0",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/engine.io": {
+      "version": "3.3.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "1.0.0",
+        "cookie": "0.3.1",
+        "debug": "~3.1.0",
+        "engine.io-parser": "~2.1.0",
+        "ws": "~6.1.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/engine.io-client": {
+      "version": "3.3.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "1.2.1",
+        "component-inherit": "0.0.3",
+        "debug": "~3.1.0",
+        "engine.io-parser": "~2.1.1",
+        "has-cors": "1.1.0",
+        "indexof": "0.0.1",
+        "parseqs": "0.0.5",
+        "parseuri": "0.0.5",
+        "ws": "~6.1.0",
+        "xmlhttprequest-ssl": "~1.5.4",
+        "yeast": "0.1.2"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/engine.io-client/node_modules/debug": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/engine.io-parser": {
+      "version": "2.1.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "after": "0.8.2",
+        "arraybuffer.slice": "~0.0.7",
+        "base64-arraybuffer": "0.1.5",
+        "blob": "0.0.5",
+        "has-binary2": "~1.0.2"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/engine.io/node_modules/debug": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/env-variable": {
+      "version": "0.0.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/errlop": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "editions": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/error": {
+      "version": "7.0.2",
+      "dev": true,
+      "dependencies": {
+        "string-template": "~0.2.1",
+        "xtend": "~4.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/error-ex": {
+      "version": "1.3.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/es6-promise": {
+      "version": "4.2.6",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/es6-promisify": {
+      "version": "6.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/escape-html": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/espree": {
+      "version": "3.5.4",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^5.5.0",
+        "acorn-jsx": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/esutils": {
+      "version": "2.0.2",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/etag": {
+      "version": "1.8.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/eventemitter3": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/execa": {
+      "version": "0.10.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/exit-hook": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/expand-brackets": {
+      "version": "0.1.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-posix-bracket": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/expand-range": {
+      "version": "1.8.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/expand-tilde": {
+      "version": "1.2.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-homedir": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/express": {
+      "version": "4.16.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.5",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.18.3",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.4",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.1.1",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.4",
+        "qs": "6.5.2",
+        "range-parser": "~1.2.0",
+        "safe-buffer": "5.1.2",
+        "send": "0.16.2",
+        "serve-static": "1.13.2",
+        "setprototypeof": "1.1.0",
+        "statuses": "~1.4.0",
+        "type-is": "~1.6.16",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/express/node_modules/path-to-regexp": {
+      "version": "0.1.7",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/ext-list": {
+      "version": "2.2.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.28.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/ext-name": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ends-with": "^0.2.0",
+        "ext-list": "^2.0.0",
+        "meow": "^3.1.0",
+        "sort-keys-length": "^1.0.0"
+      },
+      "bin": {
+        "ext-name": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/extend": {
+      "version": "3.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/extend-shallow": {
+      "version": "3.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/extend-shallow/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/external-editor": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend": "^3.0.0",
+        "spawn-sync": "^1.0.15",
+        "tmp": "^0.0.29"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/external-editor/node_modules/tmp": {
+      "version": "0.0.29",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.1"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/extglob": {
+      "version": "0.3.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/extsprintf": {
+      "version": "1.3.0",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/fast-deep-equal": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/fast-glob": {
+      "version": "2.2.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mrmlnc/readdir-enhanced": "^2.2.1",
+        "@nodelib/fs.stat": "^1.1.2",
+        "glob-parent": "^3.1.0",
+        "is-glob": "^4.0.0",
+        "merge2": "^1.2.3",
+        "micromatch": "^3.1.10"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fast-glob/node_modules/arr-diff": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fast-glob/node_modules/array-unique": {
+      "version": "0.3.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fast-glob/node_modules/braces": {
+      "version": "2.3.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fast-glob/node_modules/braces/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fast-glob/node_modules/expand-brackets": {
+      "version": "2.1.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fast-glob/node_modules/expand-brackets/node_modules/define-property": {
+      "version": "0.2.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fast-glob/node_modules/expand-brackets/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fast-glob/node_modules/expand-brackets/node_modules/is-accessor-descriptor": {
+      "version": "0.1.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fast-glob/node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of": {
+      "version": "3.2.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fast-glob/node_modules/expand-brackets/node_modules/is-data-descriptor": {
+      "version": "0.1.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fast-glob/node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of": {
+      "version": "3.2.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fast-glob/node_modules/expand-brackets/node_modules/is-descriptor": {
+      "version": "0.1.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fast-glob/node_modules/expand-brackets/node_modules/kind-of": {
+      "version": "5.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fast-glob/node_modules/extglob": {
+      "version": "2.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fast-glob/node_modules/extglob/node_modules/define-property": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fast-glob/node_modules/extglob/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fast-glob/node_modules/fill-range": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fast-glob/node_modules/fill-range/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fast-glob/node_modules/glob-parent/node_modules/is-glob": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fast-glob/node_modules/is-accessor-descriptor": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fast-glob/node_modules/is-data-descriptor": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fast-glob/node_modules/is-descriptor": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-accessor-descriptor": "^1.0.0",
+        "is-data-descriptor": "^1.0.0",
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fast-glob/node_modules/is-extglob": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fast-glob/node_modules/is-glob": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fast-glob/node_modules/is-number": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fast-glob/node_modules/is-number/node_modules/kind-of": {
+      "version": "3.2.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fast-glob/node_modules/kind-of": {
+      "version": "6.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fast-glob/node_modules/micromatch": {
+      "version": "3.1.10",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/fast-safe-stringify": {
+      "version": "2.0.6",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fecha": {
+      "version": "2.3.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/figures": {
+      "version": "1.7.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/filename-regex": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fill-range": {
+      "version": "2.2.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^3.0.0",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fill-range/node_modules/isobject": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/filled-array": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/finalhandler": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.4.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/find-port": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "~0.2.9"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/find-port/node_modules/async": {
+      "version": "0.2.10",
+      "dev": true
+    },
+    "node_modules/polymer-cli/node_modules/find-replace": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^2.0.0",
+        "test-value": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/find-up": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/findup-sync": {
+      "version": "0.4.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-file": "^0.1.0",
+        "is-glob": "^2.0.1",
+        "micromatch": "^2.3.7",
+        "resolve-dir": "^0.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/first-chunk-stream": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/follow-redirects": {
+      "version": "1.7.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/follow-redirects/node_modules/debug": {
+      "version": "3.2.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/follow-redirects/node_modules/ms": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/for-in": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/for-own": {
+      "version": "0.1.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "for-in": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/forever-agent": {
+      "version": "0.6.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fork-stream": {
+      "version": "0.0.4",
+      "dev": true,
+      "license": "BSD"
+    },
+    "node_modules/polymer-cli/node_modules/form-data": {
+      "version": "2.3.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/formatio": {
+      "version": "1.2.0",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "samsam": "1.x"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/forwarded": {
+      "version": "0.1.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fragment-cache": {
+      "version": "0.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "map-cache": "^0.2.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/freeport": {
+      "version": "1.0.5",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true
+    },
+    "node_modules/polymer-cli/node_modules/fresh": {
+      "version": "0.5.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fs-constants": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/fs-exists-sync": {
+      "version": "0.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/polymer-cli/node_modules/get-stdin": {
+      "version": "4.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/get-stream": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/get-value": {
+      "version": "2.0.6",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/getpass": {
+      "version": "0.1.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/gh-got": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "got": "^7.0.0",
+        "is-plain-obj": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/gh-got/node_modules/got": {
+      "version": "7.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^3.2.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "is-plain-obj": "^1.1.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "isurl": "^1.0.0-alpha5",
+        "lowercase-keys": "^1.0.0",
+        "p-cancelable": "^0.3.0",
+        "p-timeout": "^1.1.1",
+        "safe-buffer": "^5.0.1",
+        "timed-out": "^4.0.0",
+        "url-parse-lax": "^1.0.0",
+        "url-to-options": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/github-username": {
+      "version": "4.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "gh-got": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/glob": {
+      "version": "7.1.3",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/glob-base": {
+      "version": "0.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/glob-parent": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^2.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/glob-stream": {
+      "version": "5.3.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend": "^3.0.0",
+        "glob": "^5.0.3",
+        "glob-parent": "^3.0.0",
+        "micromatch": "^2.3.7",
+        "ordered-read-streams": "^0.3.0",
+        "through2": "^0.6.0",
+        "to-absolute-glob": "^0.1.1",
+        "unique-stream": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/glob-stream/node_modules/glob": {
+      "version": "5.0.15",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/glob-stream/node_modules/glob-parent": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/glob-stream/node_modules/is-extglob": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/glob-stream/node_modules/is-glob": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/glob-stream/node_modules/isarray": {
+      "version": "0.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/glob-stream/node_modules/readable-stream": {
+      "version": "1.0.34",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/glob-stream/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/glob-stream/node_modules/through2": {
+      "version": "0.6.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/glob-to-regexp": {
+      "version": "0.3.0",
+      "dev": true,
+      "license": "BSD"
+    },
+    "node_modules/polymer-cli/node_modules/global-dirs": {
+      "version": "0.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/global-modules": {
+      "version": "0.2.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-prefix": "^0.1.4",
+        "is-windows": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/global-modules/node_modules/is-windows": {
+      "version": "0.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/global-prefix": {
+      "version": "0.1.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "homedir-polyfill": "^1.0.0",
+        "ini": "^1.3.4",
+        "is-windows": "^0.2.0",
+        "which": "^1.2.12"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/global-prefix/node_modules/is-windows": {
+      "version": "0.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/globals": {
+      "version": "11.11.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/globby": {
+      "version": "8.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^1.0.1",
+        "dir-glob": "2.0.0",
+        "fast-glob": "^2.0.2",
+        "glob": "^7.1.2",
+        "ignore": "^3.3.5",
+        "pify": "^3.0.0",
+        "slash": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/globby/node_modules/pify": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/got": {
+      "version": "6.7.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "create-error-class": "^3.0.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "is-redirect": "^1.0.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "lowercase-keys": "^1.0.0",
+        "safe-buffer": "^5.0.1",
+        "timed-out": "^4.0.0",
+        "unzip-response": "^2.0.1",
+        "url-parse-lax": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/graceful-fs": {
+      "version": "4.1.15",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/polymer-cli/node_modules/grouped-queue": {
+      "version": "0.3.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.2"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/gulp-if": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "gulp-match": "^1.0.3",
+        "ternary-stream": "^2.0.1",
+        "through2": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/gulp-match": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^3.0.3"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/gulp-sourcemaps": {
+      "version": "1.6.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "convert-source-map": "^1.1.1",
+        "graceful-fs": "^4.1.2",
+        "strip-bom": "^2.0.0",
+        "through2": "^2.0.0",
+        "vinyl": "^1.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/gunzip-maybe": {
+      "version": "1.4.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browserify-zlib": "^0.1.4",
+        "is-deflate": "^1.0.0",
+        "is-gzip": "^1.0.0",
+        "peek-stream": "^1.1.0",
+        "pumpify": "^1.3.3",
+        "through2": "^2.0.3"
+      },
+      "bin": {
+        "gunzip-maybe": "bin.js"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/handle-thing": {
+      "version": "1.2.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/har-schema": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/har-validator": {
+      "version": "5.1.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/has-ansi": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/has-binary2": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "2.0.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/has-binary2/node_modules/isarray": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/has-color": {
+      "version": "0.1.7",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/has-cors": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/has-flag": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/has-symbol-support-x": {
+      "version": "1.4.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/has-to-string-tag-x": {
+      "version": "1.4.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbol-support-x": "^1.4.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/has-value": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/has-values": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/has-values/node_modules/is-number": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/has-values/node_modules/is-number/node_modules/kind-of": {
+      "version": "3.2.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/has-values/node_modules/kind-of": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/he": {
+      "version": "1.2.0",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/homedir-polyfill": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-passwd": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/hosted-git-info": {
+      "version": "2.7.1",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/polymer-cli/node_modules/hpack.js": {
+      "version": "2.1.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.1.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/html-minifier": {
+      "version": "3.5.21",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camel-case": "3.0.x",
+        "clean-css": "4.2.x",
+        "commander": "2.17.x",
+        "he": "1.2.x",
+        "param-case": "2.1.x",
+        "relateurl": "0.2.x",
+        "uglify-js": "3.4.x"
+      },
+      "bin": {
+        "html-minifier": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/http-deceiver": {
+      "version": "1.2.7",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/http-errors": {
+      "version": "1.6.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.4.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/http-proxy": {
+      "version": "1.17.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^3.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/http-proxy-middleware": {
+      "version": "0.17.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy": "^1.16.2",
+        "is-glob": "^3.1.0",
+        "lodash": "^4.17.2",
+        "micromatch": "^2.3.11"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/http-proxy-middleware/node_modules/is-extglob": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/http-proxy-middleware/node_modules/is-glob": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/http-signature": {
+      "version": "1.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.8",
+        "npm": ">=1.3.7"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/https-proxy-agent": {
+      "version": "2.2.1",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "3.2.6",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/polymer-cli/node_modules/iconv-lite": {
+      "version": "0.4.23",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/ieee754": {
+      "version": "1.1.12",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/polymer-cli/node_modules/ignore": {
+      "version": "3.3.10",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/import-lazy": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/indent": {
+      "version": "0.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/indent-string": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "repeating": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/indexof": {
+      "version": "0.0.1",
+      "dev": true
+    },
+    "node_modules/polymer-cli/node_modules/inflight": {
+      "version": "1.0.6",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/inherits": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/polymer-cli/node_modules/ini": {
+      "version": "1.3.5",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/inquirer": {
+      "version": "1.2.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^1.1.0",
+        "chalk": "^1.0.0",
+        "cli-cursor": "^1.0.1",
+        "cli-width": "^2.0.0",
+        "external-editor": "^1.1.0",
+        "figures": "^1.3.5",
+        "lodash": "^4.3.0",
+        "mute-stream": "0.0.6",
+        "pinkie-promise": "^2.0.0",
+        "run-async": "^2.2.0",
+        "rx": "^4.1.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.0",
+        "through": "^2.3.6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/interpret": {
+      "version": "1.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/intersect": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/invariant": {
+      "version": "2.2.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/ipaddr.js": {
+      "version": "1.8.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/is-accessor-descriptor": {
+      "version": "0.1.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/is-binary-path": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/is-buffer": {
+      "version": "1.1.6",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/is-ci": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ci-info": "^1.5.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/is-data-descriptor": {
+      "version": "0.1.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/is-deflate": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/is-descriptor": {
+      "version": "0.1.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/is-descriptor/node_modules/kind-of": {
+      "version": "5.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/is-dotfile": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/is-equal-shallow": {
+      "version": "0.1.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-primitive": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/is-extendable": {
+      "version": "0.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/is-extglob": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/is-finite": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/is-glob": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/is-gzip": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/is-installed-globally": {
+      "version": "0.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-dirs": "^0.1.0",
+        "is-path-inside": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/is-npm": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/is-number": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/is-obj": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/is-object": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/is-path-cwd": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/is-path-in-cwd": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-path-inside": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/is-path-inside": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-is-inside": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/is-plain-obj": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/is-posix-bracket": {
+      "version": "0.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/is-potential-custom-element-name": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/is-primitive": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/is-promise": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/is-redirect": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/is-retry-allowed": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/is-scoped": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "scoped-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/is-stream": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/is-utf8": {
+      "version": "0.2.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/is-valid-glob": {
+      "version": "0.3.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/is-windows": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/isarray": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/isbinaryfile": {
+      "version": "3.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-alloc": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/isexe": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/polymer-cli/node_modules/isobject": {
+      "version": "3.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/isstream": {
+      "version": "0.1.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/istextorbinary": {
+      "version": "2.5.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binaryextensions": "^2.1.2",
+        "editions": "^2.1.3",
+        "textextensions": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/isurl": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-to-string-tag-x": "^1.2.0",
+        "is-object": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/jsbn": {
+      "version": "0.1.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/jsesc": {
+      "version": "2.5.2",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/json-parse-better-errors": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/json-schema": {
+      "version": "0.2.3",
+      "dev": true
+    },
+    "node_modules/polymer-cli/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/polymer-cli/node_modules/json5": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/jsonschema": {
+      "version": "1.2.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/jsprim": {
+      "version": "1.4.1",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/kind-of": {
+      "version": "3.2.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/kuler": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colornames": "^1.1.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/latest-version": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "package-json": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/launchpad": {
+      "version": "0.7.1",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "async": "^2.0.1",
+        "browserstack": "^1.2.0",
+        "debug": "^2.2.0",
+        "plist": "^2.0.1",
+        "q": "^1.4.1",
+        "underscore": "^1.8.3"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/launchpad/node_modules/underscore": {
+      "version": "1.9.1",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/polymer-cli/node_modules/lazy-req": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/lazystream": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/load-json-file": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/locate-path": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/locate-path/node_modules/path-exists": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/lodash": {
+      "version": "4.17.11",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/lodash._reinterpolate": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/lodash.get": {
+      "version": "4.4.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/lodash.padend": {
+      "version": "4.6.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/lodash.set": {
+      "version": "4.3.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/lodash.some": {
+      "version": "4.6.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/lodash.template": {
+      "version": "4.4.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._reinterpolate": "~3.0.0",
+        "lodash.templatesettings": "^4.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/lodash.templatesettings": {
+      "version": "4.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._reinterpolate": "~3.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/log-symbols": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/logform": {
+      "version": "1.10.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colors": "^1.2.1",
+        "fast-safe-stringify": "^2.0.4",
+        "fecha": "^2.3.3",
+        "ms": "^2.1.1",
+        "triple-beam": "^1.2.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/logform/node_modules/ms": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/lolex": {
+      "version": "1.6.0",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/polymer-cli/node_modules/loose-envify": {
+      "version": "1.4.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/loud-rejection": {
+      "version": "1.6.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/lower-case": {
+      "version": "1.1.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/lowercase-keys": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/lru-cache": {
+      "version": "4.1.5",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/macos-release": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/magic-string": {
+      "version": "0.22.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vlq": "^0.2.2"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/make-dir": {
+      "version": "1.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/make-dir/node_modules/pify": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/map-cache": {
+      "version": "0.2.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/map-obj": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/map-visit": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-visit": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/matcher": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/math-random": {
+      "version": "1.0.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/md5": {
+      "version": "2.2.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/media-typer": {
+      "version": "0.3.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/mem-fs": {
+      "version": "1.1.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "through2": "^2.0.0",
+        "vinyl": "^1.1.0",
+        "vinyl-file": "^2.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/mem-fs-editor": {
+      "version": "5.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "deep-extend": "^0.6.0",
+        "ejs": "^2.5.9",
+        "glob": "^7.0.3",
+        "globby": "^8.0.1",
+        "isbinaryfile": "^3.0.2",
+        "mkdirp": "^0.5.0",
+        "multimatch": "^2.0.0",
+        "rimraf": "^2.2.8",
+        "through2": "^2.0.0",
+        "vinyl": "^2.0.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/mem-fs-editor/node_modules/clone-stats": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/mem-fs-editor/node_modules/deep-extend": {
+      "version": "0.6.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/mem-fs-editor/node_modules/replace-ext": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/mem-fs-editor/node_modules/vinyl": {
+      "version": "2.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^2.1.1",
+        "clone-buffer": "^1.0.0",
+        "clone-stats": "^1.0.0",
+        "cloneable-readable": "^1.0.0",
+        "remove-trailing-separator": "^1.0.1",
+        "replace-ext": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/meow": {
+      "version": "3.7.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/merge-descriptors": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/merge-stream": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/merge2": {
+      "version": "1.2.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/methods": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/micromatch": {
+      "version": "2.3.11",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/mime": {
+      "version": "2.4.0",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/mime-db": {
+      "version": "1.38.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/mime-types": {
+      "version": "2.1.22",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "~1.38.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/mimic-fn": {
+      "version": "1.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/mimic-response": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/polymer-cli/node_modules/minimatch": {
+      "version": "3.0.4",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/minimatch-all": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^3.0.2"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/minimist": {
+      "version": "1.2.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/mixin-deep": {
+      "version": "1.3.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/mixin-deep/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/mkdirp": {
+      "version": "0.5.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "0.0.8"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/mkdirp/node_modules/minimist": {
+      "version": "0.0.8",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/mout": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/ms": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/multer": {
+      "version": "1.4.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^0.2.11",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.1",
+        "object-assign": "^4.1.1",
+        "on-finished": "^2.3.0",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/multimatch": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-differ": "^1.0.0",
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "minimatch": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/multipipe": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer2": "^0.1.2",
+        "object-assign": "^4.1.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/mute-stream": {
+      "version": "0.0.6",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/polymer-cli/node_modules/mz": {
+      "version": "2.7.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/nanomatch": {
+      "version": "1.2.13",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/nanomatch/node_modules/arr-diff": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/nanomatch/node_modules/array-unique": {
+      "version": "0.3.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/nanomatch/node_modules/kind-of": {
+      "version": "6.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/native-promise-only": {
+      "version": "0.8.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/negotiator": {
+      "version": "0.6.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/nice-try": {
+      "version": "1.0.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/no-case": {
+      "version": "2.3.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lower-case": "^1.1.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/node-fetch": {
+      "version": "2.3.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/node-status-codes": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/nomnom": {
+      "version": "1.8.1",
+      "dev": true,
+      "dependencies": {
+        "chalk": "~0.4.0",
+        "underscore": "~1.6.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/nomnom/node_modules/ansi-styles": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/nomnom/node_modules/chalk": {
+      "version": "0.4.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "~1.0.0",
+        "has-color": "~0.1.0",
+        "strip-ansi": "~0.1.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/nomnom/node_modules/strip-ansi": {
+      "version": "0.1.1",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "strip-ansi": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/normalize-path": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "remove-trailing-separator": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/npm-run-path": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/number-is-nan": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/oauth-sign": {
+      "version": "0.9.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/object-assign": {
+      "version": "4.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/object-component": {
+      "version": "0.0.3",
+      "dev": true
+    },
+    "node_modules/polymer-cli/node_modules/object-copy": {
+      "version": "0.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/object-copy/node_modules/define-property": {
+      "version": "0.2.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/object-visit": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/object.omit": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/object.pick": {
+      "version": "1.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/obuf": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/octokit-pagination-methods": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/on-finished": {
+      "version": "2.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/on-headers": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/once": {
+      "version": "1.4.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/one-time": {
+      "version": "0.0.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/onetime": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/opn": {
+      "version": "3.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/optimist": {
+      "version": "0.6.1",
+      "dev": true,
+      "license": "MIT/X11",
+      "dependencies": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/optimist/node_modules/minimist": {
+      "version": "0.0.10",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/ordered-read-streams": {
+      "version": "0.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-stream": "^1.0.1",
+        "readable-stream": "^2.0.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/os-homedir": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/os-name": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "macos-release": "^2.0.0",
+        "windows-release": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/os-shim": {
+      "version": "0.1.3",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/osenv": {
+      "version": "0.1.5",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/p-cancelable": {
+      "version": "0.3.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/p-finally": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/p-limit": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/p-locate": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/p-map": {
+      "version": "1.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/p-timeout": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/p-try": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/package-json": {
+      "version": "4.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "got": "^6.7.1",
+        "registry-auth-token": "^3.0.1",
+        "registry-url": "^3.0.3",
+        "semver": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/pako": {
+      "version": "0.2.9",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/param-case": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^2.2.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/parse-glob": {
+      "version": "3.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/parse-json": {
+      "version": "2.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "error-ex": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/parse-passwd": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/parse5": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/parseqs": {
+      "version": "0.0.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "better-assert": "~1.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/parseuri": {
+      "version": "0.0.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "better-assert": "~1.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/parseurl": {
+      "version": "1.3.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/pascalcase": {
+      "version": "0.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/path-dirname": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/path-exists": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pinkie-promise": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/path-is-inside": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "(WTFPL OR MIT)"
+    },
+    "node_modules/polymer-cli/node_modules/path-key": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/path-parse": {
+      "version": "1.0.6",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/path-to-regexp": {
+      "version": "1.7.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/path-to-regexp/node_modules/isarray": {
+      "version": "0.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/path-type": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/peek-stream": {
+      "version": "1.1.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "duplexify": "^3.5.0",
+        "through2": "^2.0.3"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/pem": {
+      "version": "1.14.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es6-promisify": "^6.0.0",
+        "md5": "^2.2.1",
+        "os-tmpdir": "^1.0.1",
+        "which": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/pend": {
+      "version": "1.2.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/polymer-cli/node_modules/performance-now": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/pify": {
+      "version": "2.3.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/pinkie": {
+      "version": "2.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/pinkie-promise": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pinkie": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/plist": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "1.2.0",
+        "xmlbuilder": "8.2.2",
+        "xmldom": "0.1.x"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/plylog": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "logform": "^1.9.1",
+        "winston": "^3.0.0",
+        "winston-transport": "^4.2.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/polymer-analyzer": {
+      "version": "3.2.2",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/generator": "^7.0.0-beta.42",
+        "@babel/traverse": "^7.0.0-beta.42",
+        "@babel/types": "^7.0.0-beta.42",
+        "@types/babel-generator": "^6.25.1",
+        "@types/babel-traverse": "^6.25.2",
+        "@types/babel-types": "^6.25.1",
+        "@types/babylon": "^6.16.2",
+        "@types/chai-subset": "^1.3.0",
+        "@types/chalk": "^0.4.30",
+        "@types/clone": "^0.1.30",
+        "@types/cssbeautify": "^0.3.1",
+        "@types/doctrine": "^0.0.1",
+        "@types/is-windows": "^0.2.0",
+        "@types/minimatch": "^3.0.1",
+        "@types/parse5": "^2.2.34",
+        "@types/path-is-inside": "^1.0.0",
+        "@types/resolve": "0.0.6",
+        "@types/whatwg-url": "^6.4.0",
+        "babylon": "^7.0.0-beta.42",
+        "cancel-token": "^0.1.1",
+        "chalk": "^1.1.3",
+        "clone": "^2.0.0",
+        "cssbeautify": "^0.3.1",
+        "doctrine": "^2.0.2",
+        "dom5": "^3.0.0",
+        "indent": "0.0.2",
+        "is-windows": "^1.0.2",
+        "jsonschema": "^1.1.0",
+        "minimatch": "^3.0.4",
+        "parse5": "^4.0.0",
+        "path-is-inside": "^1.0.2",
+        "resolve": "^1.5.0",
+        "shady-css-parser": "^0.1.0",
+        "stable": "^0.1.6",
+        "strip-indent": "^2.0.0",
+        "vscode-uri": "^1.0.1",
+        "whatwg-url": "^6.4.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/polymer-analyzer/node_modules/@types/resolve": {
+      "version": "0.0.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/polymer-analyzer/node_modules/strip-indent": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/polymer-build": {
+      "version": "3.1.2",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.0.0",
+        "@babel/plugin-external-helpers": "^7.0.0",
+        "@babel/plugin-proposal-async-generator-functions": "^7.0.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+        "@babel/plugin-syntax-async-generators": "^7.0.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.0.0",
+        "@babel/plugin-syntax-import-meta": "^7.0.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+        "@babel/plugin-transform-arrow-functions": "^7.0.0",
+        "@babel/plugin-transform-async-to-generator": "^7.0.0",
+        "@babel/plugin-transform-block-scoped-functions": "^7.0.0",
+        "@babel/plugin-transform-block-scoping": "^7.0.0",
+        "@babel/plugin-transform-classes": "^7.0.0",
+        "@babel/plugin-transform-computed-properties": "^7.0.0",
+        "@babel/plugin-transform-destructuring": "^7.0.0",
+        "@babel/plugin-transform-duplicate-keys": "^7.0.0",
+        "@babel/plugin-transform-exponentiation-operator": "^7.0.0",
+        "@babel/plugin-transform-for-of": "^7.0.0",
+        "@babel/plugin-transform-function-name": "^7.0.0",
+        "@babel/plugin-transform-instanceof": "^7.0.0",
+        "@babel/plugin-transform-literals": "^7.0.0",
+        "@babel/plugin-transform-modules-amd": "^7.0.0",
+        "@babel/plugin-transform-object-super": "^7.0.0",
+        "@babel/plugin-transform-parameters": "^7.0.0",
+        "@babel/plugin-transform-regenerator": "^7.0.0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+        "@babel/plugin-transform-spread": "^7.0.0",
+        "@babel/plugin-transform-sticky-regex": "^7.0.0",
+        "@babel/plugin-transform-template-literals": "^7.0.0",
+        "@babel/plugin-transform-typeof-symbol": "^7.0.0",
+        "@babel/plugin-transform-unicode-regex": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@polymer/esm-amd-loader": "^1.0.0",
+        "@types/babel-types": "^6.25.1",
+        "@types/babylon": "^6.16.2",
+        "@types/gulp-if": "0.0.33",
+        "@types/html-minifier": "^3.5.1",
+        "@types/is-windows": "^0.2.0",
+        "@types/mz": "0.0.31",
+        "@types/parse5": "^2.2.34",
+        "@types/resolve": "0.0.7",
+        "@types/uuid": "^3.4.3",
+        "@types/vinyl": "^2.0.0",
+        "@types/vinyl-fs": "^2.4.8",
+        "babel-plugin-minify-guarded-expressions": "=0.4.1",
+        "babel-preset-minify": "=0.4.0-alpha.caaefb4c",
+        "babylon": "^7.0.0-beta.42",
+        "css-slam": "^2.1.2",
+        "dom5": "^3.0.0",
+        "gulp-if": "^2.0.2",
+        "html-minifier": "^3.5.10",
+        "matcher": "^1.1.0",
+        "multipipe": "^1.0.2",
+        "mz": "^2.6.0",
+        "parse5": "^4.0.0",
+        "plylog": "^1.0.0",
+        "polymer-analyzer": "^3.1.3",
+        "polymer-bundler": "^4.0.9",
+        "polymer-project-config": "^4.0.3",
+        "regenerator-runtime": "^0.11.1",
+        "stream": "0.0.2",
+        "sw-precache": "^5.1.1",
+        "uuid": "^3.2.1",
+        "vinyl": "^1.2.0",
+        "vinyl-fs": "^2.4.4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/polymer-build/node_modules/@types/resolve": {
+      "version": "0.0.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/polymer-build/node_modules/@types/vinyl-fs": {
+      "version": "2.4.11",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/glob-stream": "*",
+        "@types/node": "*",
+        "@types/vinyl": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/polymer-bundler": {
+      "version": "4.0.9",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/babel-generator": "^6.25.1",
+        "@types/babel-traverse": "^6.25.3",
+        "babel-generator": "^6.26.1",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "clone": "^2.1.0",
+        "command-line-args": "^5.0.2",
+        "command-line-usage": "^5.0.5",
+        "dom5": "^3.0.0",
+        "espree": "^3.5.2",
+        "magic-string": "^0.22.4",
+        "mkdirp": "^0.5.1",
+        "parse5": "^4.0.0",
+        "polymer-analyzer": "^3.2.2",
+        "rollup": "^1.3.0",
+        "source-map": "^0.5.6",
+        "vscode-uri": "^1.0.1"
+      },
+      "bin": {
+        "polymer-bundler": "lib/bin/polymer-bundler.js"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/polymer-linter": {
+      "version": "3.0.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/fast-levenshtein": "0.0.1",
+        "@types/parse5": "^2.2.34",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "cancel-token": "^0.1.1",
+        "css-what": "^2.1.0",
+        "dom5": "^3.0.0",
+        "fast-levenshtein": "^2.0.6",
+        "parse5": "^4.0.0",
+        "polymer-analyzer": "^3.0.0",
+        "shady-css-parser": "^0.1.0",
+        "stable": "^0.1.6",
+        "strip-indent": "^2.0.0",
+        "validate-element-name": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/polymer-linter/node_modules/strip-indent": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/polymer-project-config": {
+      "version": "4.0.3",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/parse5": "^2.2.34",
+        "browser-capabilities": "^1.0.0",
+        "jsonschema": "^1.1.1",
+        "minimatch-all": "^1.1.0",
+        "plylog": "^1.0.0",
+        "winston": "^3.0.0"
+      },
+      "peerDependencies": {
+        "polymer-analyzer": "^3.0.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/polyserve": {
+      "version": "0.27.15",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/compression": "^0.0.33",
+        "@types/content-type": "^1.1.0",
+        "@types/escape-html": "0.0.20",
+        "@types/express": "^4.0.36",
+        "@types/mime": "^2.0.0",
+        "@types/mz": "0.0.29",
+        "@types/opn": "^3.0.28",
+        "@types/parse5": "^2.2.34",
+        "@types/pem": "^1.8.1",
+        "@types/resolve": "0.0.6",
+        "@types/serve-static": "^1.7.31",
+        "@types/spdy": "^3.4.1",
+        "bower-config": "^1.4.1",
+        "browser-capabilities": "^1.0.0",
+        "command-line-args": "^5.0.2",
+        "command-line-usage": "^5.0.5",
+        "compression": "^1.6.2",
+        "content-type": "^1.0.2",
+        "cors": "^2.8.4",
+        "escape-html": "^1.0.3",
+        "express": "^4.8.5",
+        "find-port": "^1.0.1",
+        "http-proxy-middleware": "^0.17.2",
+        "lru-cache": "^4.0.2",
+        "mime": "^2.3.1",
+        "mz": "^2.4.0",
+        "opn": "^3.0.2",
+        "pem": "^1.8.3",
+        "polymer-build": "^3.1.0",
+        "polymer-project-config": "^4.0.0",
+        "requirejs": "^2.3.4",
+        "resolve": "^1.5.0",
+        "send": "^0.16.2",
+        "spdy": "^3.3.3"
+      },
+      "bin": {
+        "polyserve": "bin/polyserve"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/polyserve/node_modules/@types/mz": {
+      "version": "0.0.29",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/bluebird": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/polyserve/node_modules/@types/resolve": {
+      "version": "0.0.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/posix-character-classes": {
+      "version": "0.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/prepend-http": {
+      "version": "1.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/preserve": {
+      "version": "0.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/pretty-bytes": {
+      "version": "4.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/private": {
+      "version": "0.1.8",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/process-nextick-args": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/progress": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/proxy-addr": {
+      "version": "2.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.8.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/pseudomap": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/polymer-cli/node_modules/psl": {
+      "version": "1.1.31",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/pump": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/pumpify": {
+      "version": "1.5.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/punycode": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/q": {
+      "version": "1.5.1",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.6.0",
+        "teleport": ">=0.2.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/qs": {
+      "version": "6.5.2",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/randomatic": {
+      "version": "3.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/randomatic/node_modules/is-number": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/randomatic/node_modules/kind-of": {
+      "version": "6.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/range-parser": {
+      "version": "1.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/raw-body": {
+      "version": "2.3.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.0.0",
+        "http-errors": "1.6.3",
+        "iconv-lite": "0.4.23",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/rc": {
+      "version": "1.2.8",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/rc/node_modules/deep-extend": {
+      "version": "0.6.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/read-all-stream": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pinkie-promise": "^2.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/read-chunk": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^4.0.0",
+        "with-open-file": "^0.1.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/read-chunk/node_modules/pify": {
+      "version": "4.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/read-pkg": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/read-pkg-up": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/readable-stream": {
+      "version": "2.3.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/readdirp": {
+      "version": "2.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11",
+        "micromatch": "^3.1.10",
+        "readable-stream": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/readdirp/node_modules/arr-diff": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/readdirp/node_modules/array-unique": {
+      "version": "0.3.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/readdirp/node_modules/braces": {
+      "version": "2.3.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/readdirp/node_modules/braces/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/readdirp/node_modules/expand-brackets": {
+      "version": "2.1.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/readdirp/node_modules/expand-brackets/node_modules/define-property": {
+      "version": "0.2.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/readdirp/node_modules/expand-brackets/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/readdirp/node_modules/expand-brackets/node_modules/is-accessor-descriptor": {
+      "version": "0.1.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/readdirp/node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of": {
+      "version": "3.2.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/readdirp/node_modules/expand-brackets/node_modules/is-data-descriptor": {
+      "version": "0.1.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/readdirp/node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of": {
+      "version": "3.2.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/readdirp/node_modules/expand-brackets/node_modules/is-descriptor": {
+      "version": "0.1.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/readdirp/node_modules/expand-brackets/node_modules/kind-of": {
+      "version": "5.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/readdirp/node_modules/extglob": {
+      "version": "2.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/readdirp/node_modules/extglob/node_modules/define-property": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/readdirp/node_modules/extglob/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/readdirp/node_modules/fill-range": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/readdirp/node_modules/fill-range/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/readdirp/node_modules/is-accessor-descriptor": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/readdirp/node_modules/is-data-descriptor": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/readdirp/node_modules/is-descriptor": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-accessor-descriptor": "^1.0.0",
+        "is-data-descriptor": "^1.0.0",
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/readdirp/node_modules/is-number": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/readdirp/node_modules/is-number/node_modules/kind-of": {
+      "version": "3.2.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/readdirp/node_modules/kind-of": {
+      "version": "6.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/readdirp/node_modules/micromatch": {
+      "version": "3.1.10",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/rechoir": {
+      "version": "0.6.2",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/redent": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/reduce-flatten": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/regenerate": {
+      "version": "1.4.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/regenerate-unicode-properties": {
+      "version": "7.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regenerate": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/regenerator-runtime": {
+      "version": "0.11.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/regenerator-transform": {
+      "version": "0.13.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "private": "^0.1.6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/regex-cache": {
+      "version": "0.4.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-equal-shallow": "^0.1.3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/regex-not": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/regexpu-core": {
+      "version": "4.4.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regenerate": "^1.4.0",
+        "regenerate-unicode-properties": "^7.0.0",
+        "regjsgen": "^0.5.0",
+        "regjsparser": "^0.6.0",
+        "unicode-match-property-ecmascript": "^1.0.4",
+        "unicode-match-property-value-ecmascript": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/registry-auth-token": {
+      "version": "3.3.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/registry-url": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rc": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/regjsgen": {
+      "version": "0.5.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/regjsparser": {
+      "version": "0.6.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "jsesc": "~0.5.0"
+      },
+      "bin": {
+        "regjsparser": "bin/parser"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/regjsparser/node_modules/jsesc": {
+      "version": "0.5.0",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/relateurl": {
+      "version": "0.2.7",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/remove-trailing-separator": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/polymer-cli/node_modules/repeat-element": {
+      "version": "1.1.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/repeat-string": {
+      "version": "1.6.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/repeating": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-finite": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/replace-ext": {
+      "version": "0.0.1",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/request": {
+      "version": "2.88.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/requirejs": {
+      "version": "2.3.6",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "r_js": "bin/r.js",
+        "r.js": "bin/r.js"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/requires-port": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/resolve": {
+      "version": "1.10.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/resolve-dir": {
+      "version": "0.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expand-tilde": "^1.2.2",
+        "global-modules": "^0.2.3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/resolve-url": {
+      "version": "0.2.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/restore-cursor": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/ret": {
+      "version": "0.1.15",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/rimraf": {
+      "version": "2.6.3",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/rollup": {
+      "version": "1.4.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "0.0.39",
+        "@types/node": "^11.9.5",
+        "acorn": "^6.1.1"
+      },
+      "bin": {
+        "rollup": "bin/rollup"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/rollup/node_modules/acorn": {
+      "version": "6.1.1",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/run-async": {
+      "version": "2.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-promise": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/rx": {
+      "version": "4.1.0",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/polymer-cli/node_modules/rxjs": {
+      "version": "6.4.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/safe-regex": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ret": "~0.1.10"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/samsam": {
+      "version": "1.3.0",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/polymer-cli/node_modules/sauce-connect-launcher": {
+      "version": "1.2.4",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "adm-zip": "~0.4.3",
+        "async": "^2.1.2",
+        "https-proxy-agent": "^2.2.1",
+        "lodash": "^4.16.6",
+        "rimraf": "^2.5.4"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/scoped-regex": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/select-hose": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/selenium-standalone": {
+      "version": "6.15.6",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "async": "^2.6.2",
+        "commander": "^2.19.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.1.1",
+        "lodash": "^4.17.11",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "progress": "2.0.3",
+        "request": "2.88.0",
+        "tar-stream": "2.0.0",
+        "urijs": "^1.19.1",
+        "which": "^1.3.1",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "selenium-standalone": "bin/selenium-standalone",
+        "start-selenium": "bin/start-selenium"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/selenium-standalone/node_modules/bl": {
+      "version": "2.2.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/selenium-standalone/node_modules/bl/node_modules/readable-stream": {
+      "version": "2.3.6",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/selenium-standalone/node_modules/commander": {
+      "version": "2.19.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/polymer-cli/node_modules/selenium-standalone/node_modules/debug": {
+      "version": "4.1.1",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/selenium-standalone/node_modules/ms": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/polymer-cli/node_modules/selenium-standalone/node_modules/readable-stream": {
+      "version": "3.2.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/selenium-standalone/node_modules/tar-stream": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bl": "^2.2.0",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/semver": {
+      "version": "5.6.0",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/semver-diff": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^5.0.3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/send": {
+      "version": "0.16.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.6.2",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/send/node_modules/mime": {
+      "version": "1.4.1",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/serve-static": {
+      "version": "1.13.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
+        "send": "0.16.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/server-destroy": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/polymer-cli/node_modules/serviceworker-cache-polyfill": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/set-value": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/set-value/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/setprototypeof": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/polymer-cli/node_modules/shady-css-parser": {
+      "version": "0.1.0",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/polymer-cli/node_modules/shebang-command": {
+      "version": "1.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/shelljs": {
+      "version": "0.8.3",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/signal-exit": {
+      "version": "3.0.2",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/polymer-cli/node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/sinon-chai": {
+      "version": "2.14.0",
+      "dev": true,
+      "license": "(BSD-2-Clause OR WTFPL)",
+      "peerDependencies": {
+        "chai": ">=1.9.2 <5",
+        "sinon": "^1.4.0 || ^2.1.0 || ^3.0.0 || ^4.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/slash": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/slide": {
+      "version": "1.1.6",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/snapdragon": {
+      "version": "0.8.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/snapdragon-node": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/snapdragon-node/node_modules/define-property": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/snapdragon-node/node_modules/is-accessor-descriptor": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/snapdragon-node/node_modules/is-data-descriptor": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/snapdragon-node/node_modules/is-descriptor": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-accessor-descriptor": "^1.0.0",
+        "is-data-descriptor": "^1.0.0",
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/snapdragon-node/node_modules/kind-of": {
+      "version": "6.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/snapdragon-util": {
+      "version": "3.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/snapdragon/node_modules/define-property": {
+      "version": "0.2.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/snapdragon/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/socket.io": {
+      "version": "2.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.1.0",
+        "engine.io": "~3.3.1",
+        "has-binary2": "~1.0.2",
+        "socket.io-adapter": "~1.1.0",
+        "socket.io-client": "2.2.0",
+        "socket.io-parser": "~3.3.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/socket.io-adapter": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/socket.io-client": {
+      "version": "2.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "backo2": "1.0.2",
+        "base64-arraybuffer": "0.1.5",
+        "component-bind": "1.0.0",
+        "component-emitter": "1.2.1",
+        "debug": "~3.1.0",
+        "engine.io-client": "~3.3.1",
+        "has-binary2": "~1.0.2",
+        "has-cors": "1.1.0",
+        "indexof": "0.0.1",
+        "object-component": "0.0.3",
+        "parseqs": "0.0.5",
+        "parseuri": "0.0.5",
+        "socket.io-parser": "~3.3.0",
+        "to-array": "0.1.4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/socket.io-client/node_modules/debug": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/socket.io-parser": {
+      "version": "3.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "1.2.1",
+        "debug": "~3.1.0",
+        "isarray": "2.0.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/socket.io-parser/node_modules/debug": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/socket.io-parser/node_modules/isarray": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/socket.io/node_modules/debug": {
+      "version": "4.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/socket.io/node_modules/ms": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/sort-keys": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/sort-keys-length": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sort-keys": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/source-map": {
+      "version": "0.5.7",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/source-map-resolve": {
+      "version": "0.5.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/source-map-url": {
+      "version": "0.4.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/spawn-sync": {
+      "version": "1.0.15",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "concat-stream": "^1.4.7",
+        "os-shim": "^0.1.2"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/spdx-correct": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/spdx-exceptions": {
+      "version": "2.2.0",
+      "dev": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/polymer-cli/node_modules/spdx-expression-parse": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/spdx-license-ids": {
+      "version": "3.0.3",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/polymer-cli/node_modules/spdy": {
+      "version": "3.4.7",
+      "dev": true,
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^2.6.8",
+        "handle-thing": "^1.2.5",
+        "http-deceiver": "^1.2.7",
+        "safe-buffer": "^5.0.1",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.18"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/spdy-transport": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^2.6.8",
+        "detect-node": "^2.0.3",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.1",
+        "readable-stream": "^2.2.9",
+        "safe-buffer": "^5.0.1",
+        "wbuf": "^1.7.2"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/split-string": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/sshpk": {
+      "version": "1.16.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/stable": {
+      "version": "0.1.8",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/stack-trace": {
+      "version": "0.0.10",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/stacky": {
+      "version": "1.3.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "chalk": "^1.1.1",
+        "lodash": "^3.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/stacky/node_modules/lodash": {
+      "version": "3.10.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/static-extend": {
+      "version": "0.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/static-extend/node_modules/define-property": {
+      "version": "0.2.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/statuses": {
+      "version": "1.4.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/stream": {
+      "version": "0.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emitter-component": "^1.1.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/stream-shift": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/streamsearch": {
+      "version": "0.1.2",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/string-template": {
+      "version": "0.2.1",
+      "dev": true
+    },
+    "node_modules/polymer-cli/node_modules/string-width": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/strip-bom": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-utf8": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/strip-bom-stream": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "first-chunk-stream": "^1.0.0",
+        "strip-bom": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/strip-eof": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/strip-indent": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-stdin": "^4.0.1"
+      },
+      "bin": {
+        "strip-indent": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/supports-color": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/sw-precache": {
+      "version": "5.2.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dom-urls": "^1.1.0",
+        "es6-promise": "^4.0.5",
+        "glob": "^7.1.1",
+        "lodash.defaults": "^4.2.0",
+        "lodash.template": "^4.4.0",
+        "meow": "^3.7.0",
+        "mkdirp": "^0.5.1",
+        "pretty-bytes": "^4.0.2",
+        "sw-toolbox": "^3.4.0",
+        "update-notifier": "^2.3.0"
+      },
+      "bin": {
+        "sw-precache": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/sw-precache/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/sw-precache/node_modules/chalk": {
+      "version": "2.4.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/sw-precache/node_modules/supports-color": {
+      "version": "5.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/sw-precache/node_modules/update-notifier": {
+      "version": "2.5.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boxen": "^1.2.1",
+        "chalk": "^2.0.1",
+        "configstore": "^3.0.0",
+        "import-lazy": "^2.1.0",
+        "is-ci": "^1.0.10",
+        "is-installed-globally": "^0.1.0",
+        "is-npm": "^1.0.0",
+        "latest-version": "^3.0.0",
+        "semver-diff": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/sw-toolbox": {
+      "version": "3.6.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "path-to-regexp": "^1.0.1",
+        "serviceworker-cache-polyfill": "^4.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/table-layout": {
+      "version": "0.4.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^2.0.0",
+        "deep-extend": "~0.6.0",
+        "lodash.padend": "^4.6.1",
+        "typical": "^2.6.1",
+        "wordwrapjs": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/table-layout/node_modules/deep-extend": {
+      "version": "0.6.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/tar-fs": {
+      "version": "1.16.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.0.1",
+        "mkdirp": "^0.5.1",
+        "pump": "^1.0.0",
+        "tar-stream": "^1.1.2"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/tar-fs/node_modules/pump": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/tar-stream": {
+      "version": "1.6.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.2.0",
+        "end-of-stream": "^1.0.0",
+        "fs-constants": "^1.0.0",
+        "readable-stream": "^2.3.0",
+        "to-buffer": "^1.1.1",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/temp": {
+      "version": "0.8.3",
+      "dev": true,
+      "engines": [
+        "node >=0.8.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "^1.0.0",
+        "rimraf": "~2.2.6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/temp/node_modules/rimraf": {
+      "version": "2.2.8",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/term-size": {
+      "version": "1.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/term-size/node_modules/cross-spawn": {
+      "version": "5.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/term-size/node_modules/execa": {
+      "version": "0.7.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/ternary-stream": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexify": "^3.5.0",
+        "fork-stream": "^0.0.4",
+        "merge-stream": "^1.0.0",
+        "through2": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/test-value": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^2.0.0",
+        "typical": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/text-encoding": {
+      "version": "0.6.4",
+      "dev": true,
+      "license": "Unlicense"
+    },
+    "node_modules/polymer-cli/node_modules/text-hex": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/text-table": {
+      "version": "0.2.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/textextensions": {
+      "version": "2.4.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/thenify": {
+      "version": "3.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/thenify-all": {
+      "version": "1.6.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/through": {
+      "version": "2.3.8",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/through2": {
+      "version": "2.0.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/through2-filter": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "through2": "~2.0.0",
+        "xtend": "~4.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/timed-out": {
+      "version": "4.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/to-absolute-glob": {
+      "version": "0.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/to-absolute-glob/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/to-array": {
+      "version": "0.1.4",
+      "dev": true
+    },
+    "node_modules/polymer-cli/node_modules/to-buffer": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/to-fast-properties": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/to-object-path": {
+      "version": "0.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/to-regex": {
+      "version": "3.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/to-regex-range": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/to-regex-range/node_modules/is-number": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/tough-cookie": {
+      "version": "2.4.3",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/tough-cookie/node_modules/punycode": {
+      "version": "1.4.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/tr46": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/trim-newlines": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/trim-right": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/triple-beam": {
+      "version": "1.3.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/tslib": {
+      "version": "1.9.3",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/polymer-cli/node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "dev": true,
+      "license": "Unlicense"
+    },
+    "node_modules/polymer-cli/node_modules/type-detect": {
+      "version": "4.0.8",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/type-is": {
+      "version": "1.6.16",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.18"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/typedarray": {
+      "version": "0.0.6",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/typical": {
+      "version": "2.6.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/ua-parser-js": {
+      "version": "0.7.19",
+      "dev": true,
+      "license": "(GPL-2.0 OR MIT)",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/uglify-js": {
+      "version": "3.4.9",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "commander": "~2.17.1",
+        "source-map": "~0.6.1"
+      },
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/uglify-js/node_modules/source-map": {
+      "version": "0.6.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/underscore": {
+      "version": "1.6.0",
+      "dev": true
+    },
+    "node_modules/polymer-cli/node_modules/unicode-canonical-property-names-ecmascript": {
+      "version": "1.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/unicode-match-property-ecmascript": {
+      "version": "1.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unicode-canonical-property-names-ecmascript": "^1.0.4",
+        "unicode-property-aliases-ecmascript": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/unicode-match-property-value-ecmascript": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/unicode-property-aliases-ecmascript": {
+      "version": "1.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/union-value": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^0.4.3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/union-value/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/union-value/node_modules/set-value": {
+      "version": "0.4.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.1",
+        "to-object-path": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/unique-stream": {
+      "version": "2.3.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "through2-filter": "^3.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/unique-stream/node_modules/through2-filter": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "through2": "~2.0.0",
+        "xtend": "~4.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/unique-string": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crypto-random-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/universal-user-agent": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "os-name": "^3.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/unpipe": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/unset-value": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/unset-value/node_modules/has-value": {
+      "version": "0.3.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-value": "^2.0.3",
+        "has-values": "^0.1.4",
+        "isobject": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/unset-value/node_modules/has-value/node_modules/isobject": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/unset-value/node_modules/has-values": {
+      "version": "0.1.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/untildify": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-homedir": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/unzip-response": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/update-notifier": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boxen": "^0.6.0",
+        "chalk": "^1.0.0",
+        "configstore": "^2.0.0",
+        "is-npm": "^1.0.0",
+        "latest-version": "^2.0.0",
+        "lazy-req": "^1.1.0",
+        "semver-diff": "^2.0.0",
+        "xdg-basedir": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/update-notifier/node_modules/ansi-align": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^1.0.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/update-notifier/node_modules/boxen": {
+      "version": "0.6.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-align": "^1.1.0",
+        "camelcase": "^2.1.0",
+        "chalk": "^1.1.1",
+        "cli-boxes": "^1.0.0",
+        "filled-array": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "repeating": "^2.0.0",
+        "string-width": "^1.0.1",
+        "widest-line": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/update-notifier/node_modules/configstore": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dot-prop": "^3.0.0",
+        "graceful-fs": "^4.1.2",
+        "mkdirp": "^0.5.0",
+        "object-assign": "^4.0.1",
+        "os-tmpdir": "^1.0.0",
+        "osenv": "^0.1.0",
+        "uuid": "^2.0.1",
+        "write-file-atomic": "^1.1.2",
+        "xdg-basedir": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/update-notifier/node_modules/dot-prop": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-obj": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/update-notifier/node_modules/got": {
+      "version": "5.7.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "create-error-class": "^3.0.1",
+        "duplexer2": "^0.1.4",
+        "is-redirect": "^1.0.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "lowercase-keys": "^1.0.0",
+        "node-status-codes": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "parse-json": "^2.1.0",
+        "pinkie-promise": "^2.0.0",
+        "read-all-stream": "^3.0.0",
+        "readable-stream": "^2.0.5",
+        "timed-out": "^3.0.0",
+        "unzip-response": "^1.0.2",
+        "url-parse-lax": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0 <7"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/update-notifier/node_modules/latest-version": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "package-json": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/update-notifier/node_modules/package-json": {
+      "version": "2.4.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "got": "^5.0.0",
+        "registry-auth-token": "^3.0.1",
+        "registry-url": "^3.0.3",
+        "semver": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/update-notifier/node_modules/timed-out": {
+      "version": "3.1.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/update-notifier/node_modules/unzip-response": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/update-notifier/node_modules/uuid": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/update-notifier/node_modules/widest-line": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/update-notifier/node_modules/write-file-atomic": {
+      "version": "1.3.4",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "slide": "^1.1.5"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/update-notifier/node_modules/xdg-basedir": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-homedir": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/upper-case": {
+      "version": "1.1.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/uri-js": {
+      "version": "4.2.2",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/urijs": {
+      "version": "1.19.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/urix": {
+      "version": "0.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/url-parse-lax": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prepend-http": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/url-template": {
+      "version": "2.0.8",
+      "dev": true,
+      "license": "BSD"
+    },
+    "node_modules/polymer-cli/node_modules/url-to-options": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/use": {
+      "version": "3.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/utils-merge": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/uuid": {
+      "version": "3.3.2",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/vali-date": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/validate-element-name": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-potential-custom-element-name": "^1.0.0",
+        "log-symbols": "^1.0.0",
+        "meow": "^3.7.0"
+      },
+      "bin": {
+        "validate-element-name": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/vargs": {
+      "version": "0.1.0",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.93"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/vary": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/verror": {
+      "version": "1.10.0",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/vinyl": {
+      "version": "1.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.0",
+        "clone-stats": "^0.0.1",
+        "replace-ext": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 0.9"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/vinyl-file": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.3.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0",
+        "strip-bom-stream": "^2.0.0",
+        "vinyl": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/vinyl-file/node_modules/first-chunk-stream": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/vinyl-file/node_modules/strip-bom-stream": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "first-chunk-stream": "^2.0.0",
+        "strip-bom": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/vinyl-fs": {
+      "version": "2.4.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexify": "^3.2.0",
+        "glob-stream": "^5.3.2",
+        "graceful-fs": "^4.0.0",
+        "gulp-sourcemaps": "1.6.0",
+        "is-valid-glob": "^0.3.0",
+        "lazystream": "^1.0.0",
+        "lodash.isequal": "^4.0.0",
+        "merge-stream": "^1.0.0",
+        "mkdirp": "^0.5.0",
+        "object-assign": "^4.0.0",
+        "readable-stream": "^2.0.4",
+        "strip-bom": "^2.0.0",
+        "strip-bom-stream": "^1.0.0",
+        "through2": "^2.0.0",
+        "through2-filter": "^2.0.0",
+        "vali-date": "^1.0.0",
+        "vinyl": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/vinyl/node_modules/clone": {
+      "version": "1.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/vlq": {
+      "version": "0.2.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/vscode-uri": {
+      "version": "1.0.6",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/wbuf": {
+      "version": "1.7.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/wct-local": {
+      "version": "2.1.3",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "@types/express": "^4.0.30",
+        "@types/freeport": "^1.0.19",
+        "@types/launchpad": "^0.6.0",
+        "@types/which": "^1.3.1",
+        "chalk": "^2.3.0",
+        "cleankill": "^2.0.0",
+        "freeport": "^1.0.4",
+        "launchpad": "^0.7.0",
+        "selenium-standalone": "^6.7.0",
+        "which": "^1.0.8"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/wct-local/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/wct-local/node_modules/chalk": {
+      "version": "2.4.2",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/wct-local/node_modules/supports-color": {
+      "version": "5.5.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/wct-sauce": {
+      "version": "2.1.0",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "chalk": "^2.4.1",
+        "cleankill": "^2.0.0",
+        "lodash": "^4.17.10",
+        "request": "^2.85.0",
+        "sauce-connect-launcher": "^1.0.0",
+        "temp": "^0.8.1",
+        "uuid": "^3.2.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/wct-sauce/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/wct-sauce/node_modules/chalk": {
+      "version": "2.4.2",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/wct-sauce/node_modules/supports-color": {
+      "version": "5.5.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/wd": {
+      "version": "1.11.1",
+      "dev": true,
+      "engines": [
+        "node"
+      ],
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "archiver": "2.1.1",
+        "async": "2.0.1",
+        "lodash": "4.17.11",
+        "mkdirp": "^0.5.1",
+        "q": "1.4.1",
+        "request": "2.88.0",
+        "vargs": "0.1.0"
+      },
+      "bin": {
+        "wd": "lib/bin.js"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/wd/node_modules/async": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.8.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/wd/node_modules/q": {
+      "version": "1.4.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0",
+        "teleport": ">=0.2.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester": {
+      "version": "6.9.2",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@polymer/sinonjs": "^1.14.1",
+        "@polymer/test-fixture": "^0.0.3",
+        "@webcomponents/webcomponentsjs": "^1.0.7",
+        "accessibility-developer-tools": "^2.12.0",
+        "async": "^2.4.1",
+        "body-parser": "^1.17.2",
+        "bower-config": "^1.4.0",
+        "chalk": "^1.1.3",
+        "cleankill": "^2.0.0",
+        "express": "^4.15.3",
+        "findup-sync": "^2.0.0",
+        "glob": "^7.1.2",
+        "lodash": "^3.10.1",
+        "multer": "^1.3.0",
+        "nomnom": "^1.8.1",
+        "polyserve": "^0.27.13",
+        "resolve": "^1.5.0",
+        "semver": "^5.3.0",
+        "send": "^0.16.1",
+        "server-destroy": "^1.0.1",
+        "sinon": "^2.3.5",
+        "sinon-chai": "^2.10.0",
+        "socket.io": "^2.0.3",
+        "stacky": "^1.3.1",
+        "wd": "^1.2.0"
+      },
+      "bin": {
+        "wct": "bin/wct",
+        "wct-st": "bin/wct-st"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      },
+      "optionalDependencies": {
+        "update-notifier": "^2.2.0",
+        "wct-local": "^2.1.1",
+        "wct-sauce": "^2.0.2"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/arr-diff": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/array-unique": {
+      "version": "0.3.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/braces": {
+      "version": "2.3.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/braces/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/detect-file": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/expand-brackets": {
+      "version": "2.1.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/expand-brackets/node_modules/define-property": {
+      "version": "0.2.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/expand-brackets/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/expand-brackets/node_modules/is-accessor-descriptor": {
+      "version": "0.1.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of": {
+      "version": "3.2.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/expand-brackets/node_modules/is-data-descriptor": {
+      "version": "0.1.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of": {
+      "version": "3.2.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/expand-brackets/node_modules/is-descriptor": {
+      "version": "0.1.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/expand-brackets/node_modules/kind-of": {
+      "version": "5.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/expand-tilde": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "homedir-polyfill": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/extglob": {
+      "version": "2.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/extglob/node_modules/define-property": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/extglob/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/fill-range": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/fill-range/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/findup-sync": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-file": "^1.0.0",
+        "is-glob": "^3.1.0",
+        "micromatch": "^3.0.4",
+        "resolve-dir": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/global-modules": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-prefix": "^1.0.1",
+        "is-windows": "^1.0.1",
+        "resolve-dir": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/global-prefix": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expand-tilde": "^2.0.2",
+        "homedir-polyfill": "^1.0.1",
+        "ini": "^1.3.4",
+        "is-windows": "^1.0.1",
+        "which": "^1.2.14"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/is-accessor-descriptor": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/is-data-descriptor": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/is-descriptor": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-accessor-descriptor": "^1.0.0",
+        "is-data-descriptor": "^1.0.0",
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/is-extglob": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/is-glob": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/is-number": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/is-number/node_modules/kind-of": {
+      "version": "3.2.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/kind-of": {
+      "version": "6.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/lodash": {
+      "version": "3.10.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/micromatch": {
+      "version": "3.1.10",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/resolve-dir": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expand-tilde": "^2.0.0",
+        "global-modules": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/sinon": {
+      "version": "2.4.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "diff": "^3.1.0",
+        "formatio": "1.2.0",
+        "lolex": "^1.6.0",
+        "native-promise-only": "^0.8.1",
+        "path-to-regexp": "^1.7.0",
+        "samsam": "^1.1.3",
+        "text-encoding": "0.6.4",
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.1.103"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/supports-color": {
+      "version": "5.5.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/update-notifier": {
+      "version": "2.5.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "dependencies": {
+        "boxen": "^1.2.1",
+        "chalk": "^2.0.1",
+        "configstore": "^3.0.0",
+        "import-lazy": "^2.1.0",
+        "is-ci": "^1.0.10",
+        "is-installed-globally": "^0.1.0",
+        "is-npm": "^1.0.0",
+        "latest-version": "^3.0.0",
+        "semver-diff": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/web-component-tester/node_modules/update-notifier/node_modules/chalk": {
+      "version": "2.4.2",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/webidl-conversions": {
+      "version": "4.0.2",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/polymer-cli/node_modules/whatwg-url": {
+      "version": "6.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/which": {
+      "version": "1.3.1",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/widest-line": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/widest-line/node_modules/ansi-regex": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/widest-line/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/widest-line/node_modules/string-width": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/widest-line/node_modules/strip-ansi": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/windows-release": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^0.10.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/winston": {
+      "version": "3.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^2.6.1",
+        "diagnostics": "^1.1.1",
+        "is-stream": "^1.1.0",
+        "logform": "^2.1.1",
+        "one-time": "0.0.4",
+        "readable-stream": "^3.1.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.3.0"
+      },
+      "engines": {
+        "node": ">= 6.4.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/winston-transport": {
+      "version": "4.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.3.6",
+        "triple-beam": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 6.4.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/winston/node_modules/logform": {
+      "version": "2.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colors": "^1.2.1",
+        "fast-safe-stringify": "^2.0.4",
+        "fecha": "^2.3.3",
+        "ms": "^2.1.1",
+        "triple-beam": "^1.3.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/winston/node_modules/ms": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/winston/node_modules/readable-stream": {
+      "version": "3.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/with-open-file": {
+      "version": "0.1.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0",
+        "p-try": "^2.0.0",
+        "pify": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/with-open-file/node_modules/pify": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/wordwrap": {
+      "version": "0.0.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/wordwrapjs": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "reduce-flatten": "^1.0.1",
+        "typical": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/wrappy": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/polymer-cli/node_modules/write-file-atomic": {
+      "version": "2.4.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/ws": {
+      "version": "6.1.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-limiter": "~1.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/xdg-basedir": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/xmlbuilder": {
+      "version": "8.2.2",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/xmldom": {
+      "version": "0.1.27",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=0.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/xmlhttprequest-ssl": {
+      "version": "1.5.5",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/xtend": {
+      "version": "4.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yallist": {
+      "version": "2.1.2",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/polymer-cli/node_modules/yauzl": {
+      "version": "2.10.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeast": {
+      "version": "0.1.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-environment": {
+      "version": "1.6.6",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "chalk": "^1.0.0",
+        "debug": "^2.0.0",
+        "diff": "^2.1.2",
+        "escape-string-regexp": "^1.0.2",
+        "globby": "^4.0.0",
+        "grouped-queue": "^0.3.0",
+        "inquirer": "^1.0.2",
+        "lodash": "^4.11.1",
+        "log-symbols": "^1.0.1",
+        "mem-fs": "^1.1.0",
+        "text-table": "^0.2.0",
+        "untildify": "^2.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-environment/node_modules/diff": {
+      "version": "2.2.3",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-environment/node_modules/glob": {
+      "version": "6.0.4",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-environment/node_modules/globby": {
+      "version": "4.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^6.0.1",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator": {
+      "version": "3.2.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "async": "^2.6.0",
+        "chalk": "^2.3.0",
+        "cli-table": "^0.3.1",
+        "cross-spawn": "^6.0.5",
+        "dargs": "^6.0.0",
+        "dateformat": "^3.0.3",
+        "debug": "^4.1.0",
+        "detect-conflict": "^1.0.0",
+        "error": "^7.0.2",
+        "find-up": "^3.0.0",
+        "github-username": "^4.0.0",
+        "istextorbinary": "^2.2.1",
+        "lodash": "^4.17.10",
+        "make-dir": "^1.1.0",
+        "mem-fs-editor": "^5.0.0",
+        "minimist": "^1.2.0",
+        "pretty-bytes": "^5.1.0",
+        "read-chunk": "^3.0.0",
+        "read-pkg-up": "^4.0.0",
+        "rimraf": "^2.6.2",
+        "run-async": "^2.0.0",
+        "shelljs": "^0.8.0",
+        "text-table": "^0.2.0",
+        "through2": "^3.0.0",
+        "yeoman-environment": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator/node_modules/ansi-escapes": {
+      "version": "3.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator/node_modules/ansi-regex": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator/node_modules/chalk": {
+      "version": "2.4.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator/node_modules/cli-cursor": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator/node_modules/debug": {
+      "version": "4.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator/node_modules/external-editor": {
+      "version": "3.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator/node_modules/figures": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator/node_modules/find-up": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator/node_modules/inquirer": {
+      "version": "6.2.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.11",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.4.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.0.0",
+        "through": "^2.3.6"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator/node_modules/inquirer/node_modules/ansi-regex": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator/node_modules/inquirer/node_modules/strip-ansi": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator/node_modules/load-json-file": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator/node_modules/log-symbols": {
+      "version": "2.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator/node_modules/ms": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator/node_modules/mute-stream": {
+      "version": "0.0.7",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator/node_modules/onetime": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator/node_modules/parse-json": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator/node_modules/path-type": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator/node_modules/pify": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator/node_modules/pretty-bytes": {
+      "version": "5.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator/node_modules/read-pkg": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-json-file": "^4.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator/node_modules/read-pkg-up": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^3.0.0",
+        "read-pkg": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator/node_modules/restore-cursor": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator/node_modules/string-width": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator/node_modules/strip-ansi": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator/node_modules/supports-color": {
+      "version": "5.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator/node_modules/through2": {
+      "version": "3.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "2 || 3"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator/node_modules/tmp": {
+      "version": "0.0.33",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator/node_modules/untildify": {
+      "version": "3.0.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator/node_modules/yeoman-environment": {
+      "version": "2.3.4",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "chalk": "^2.4.1",
+        "cross-spawn": "^6.0.5",
+        "debug": "^3.1.0",
+        "diff": "^3.5.0",
+        "escape-string-regexp": "^1.0.2",
+        "globby": "^8.0.1",
+        "grouped-queue": "^0.3.3",
+        "inquirer": "^6.0.0",
+        "is-scoped": "^1.0.0",
+        "lodash": "^4.17.10",
+        "log-symbols": "^2.2.0",
+        "mem-fs": "^1.1.0",
+        "strip-ansi": "^4.0.0",
+        "text-table": "^0.2.0",
+        "untildify": "^3.0.3"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/yeoman-generator/node_modules/yeoman-environment/node_modules/debug": {
+      "version": "3.2.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/polymer-cli/node_modules/zip-stream": {
+      "version": "1.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^1.3.0",
+        "compress-commons": "^1.2.0",
+        "lodash": "^4.8.0",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+      "optional": true
+    },
+    "node_modules/samsam": {
+      "version": "1.1.2",
+      "dev": true
+    },
+    "node_modules/sinon": {
+      "version": "1.17.7",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "formatio": "1.1.1",
+        "lolex": "1.3.2",
+        "samsam": "1.1.2",
+        "util": ">=0.10.3 <1"
+      },
+      "engines": {
+        "node": ">=0.1.103"
+      }
+    },
+    "node_modules/sinon-chai": {
+      "version": "2.14.0",
+      "dev": true,
+      "license": "(BSD-2-Clause OR WTFPL)",
+      "peerDependencies": {
+        "chai": ">=1.9.2 <5",
+        "sinon": "^1.4.0 || ^2.1.0 || ^3.0.0 || ^4.0.0"
+      }
+    },
+    "node_modules/stacky": {
+      "version": "1.3.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "chalk": "^1.1.1",
+        "lodash": "^3.0.0"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "3.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/util": {
+      "version": "0.11.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "2.0.3"
+      }
+    },
+    "node_modules/wct-browser-legacy": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "http://polymer.github.io/LICENSE.txt",
+      "dependencies": {
+        "@polymer/polymer": "^3.0.0",
+        "@polymer/sinonjs": "^1.14.1",
+        "@polymer/test-fixture": "^3.0.0-pre.1",
+        "@webcomponents/webcomponentsjs": "^2.0.0",
+        "accessibility-developer-tools": "^2.12.0",
+        "async": "^1.5.2",
+        "chai": "^3.5.0",
+        "lodash": "^3.10.1",
+        "mocha": "^3.4.2",
+        "sinon": "^1.17.1",
+        "sinon-chai": "^2.10.0",
+        "stacky": "^1.3.1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "ISC"
+    }
+  },
+  "dependencies": {
+    "@cwmr/iron-star-rating": {
+      "version": "3.1.4",
+      "requires": {
+        "@polymer/iron-icon": "^3.0.0",
+        "@polymer/iron-icons": "^3.0.0",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/app-layout": {
+      "version": "3.0.2",
+      "requires": {
+        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
+        "@polymer/iron-media-query": "^3.0.0-pre.26",
+        "@polymer/iron-resizable-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-scroll-target-behavior": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/app-route": {
+      "version": "3.0.2",
+      "requires": {
+        "@polymer/iron-location": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/font-roboto": {
+      "version": "3.0.2"
+    },
+    "@polymer/iron-a11y-announcer": {
+      "version": "3.0.2",
+      "requires": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/iron-a11y-keys-behavior": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/iron-ajax": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/iron-autogrow-textarea": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/iron-behaviors": "^3.0.0-pre.26",
+        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
+        "@polymer/iron-validatable-behavior": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/iron-behaviors": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/iron-checked-element-behavior": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/iron-form-element-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-validatable-behavior": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/iron-collapse": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/iron-resizable-behavior": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/iron-dropdown": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/iron-behaviors": "^3.0.0-pre.26",
+        "@polymer/iron-overlay-behavior": "^3.0.0-pre.27",
+        "@polymer/neon-animation": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/iron-fit-behavior": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/iron-flex-layout": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/iron-form": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/iron-ajax": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/iron-form-element-behavior": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/iron-icon": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
+        "@polymer/iron-meta": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/iron-icons": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/iron-icon": "^3.0.0-pre.26",
+        "@polymer/iron-iconset-svg": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/iron-iconset-svg": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/iron-meta": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/iron-image": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/iron-input": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/iron-a11y-announcer": "^3.0.0-pre.26",
+        "@polymer/iron-validatable-behavior": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/iron-list": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@polymer/iron-list/-/iron-list-3.1.0.tgz",
+      "integrity": "sha512-Eiv6xd3h3oPmn8SXFntXVfC3ZnegH+KHAxiKLKcOASFSRY3mHnr2AdcnExUJ9ItoCMA5UzKaM/0U22eWzGERtA==",
+      "requires": {
+        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-resizable-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-scroll-target-behavior": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/iron-location": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/iron-media-query": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/iron-menu-behavior": {
+      "version": "3.0.2",
+      "requires": {
+        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
+        "@polymer/iron-selector": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/iron-meta": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/iron-overlay-behavior": {
+      "version": "3.0.2",
+      "requires": {
+        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-fit-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-resizable-behavior": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/iron-pages": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/iron-resizable-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-selector": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/iron-resizable-behavior": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/iron-scroll-target-behavior": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/iron-selector": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/iron-validatable-behavior": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/iron-meta": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/lit-element": {
+      "version": "0.6.5",
+      "requires": {
+        "lit-html": "^1.0.0-rc.1"
+      }
+    },
+    "@polymer/neon-animation": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/iron-resizable-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-selector": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/paper-badge": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@polymer/paper-badge/-/paper-badge-3.1.0.tgz",
+      "integrity": "sha512-5SH5Xw9ji16BjIZT2wY7oVgWX01fDyzm/nGnDi55iujPGsfaPV1itze7c9/3wlmgI+b28KBApUY9hW8f0h2V6g==",
+      "requires": {
+        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
+        "@polymer/iron-icon": "^3.0.0-pre.26",
+        "@polymer/iron-resizable-behavior": "^3.0.0-pre.26",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/paper-behaviors": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/iron-behaviors": "^3.0.0-pre.26",
+        "@polymer/iron-checked-element-behavior": "^3.0.0-pre.26",
+        "@polymer/paper-ripple": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/paper-button": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
+        "@polymer/paper-behaviors": "^3.0.0-pre.27",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/paper-card": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
+        "@polymer/iron-image": "^3.0.0-pre.26",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/paper-checkbox": {
+      "version": "3.1.0",
+      "requires": {
+        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-checked-element-behavior": "^3.0.0-pre.26",
+        "@polymer/paper-behaviors": "^3.0.0-pre.27",
+        "@polymer/paper-ripple": "^3.0.0-pre.26",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/paper-dialog": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/iron-overlay-behavior": "^3.0.0-pre.27",
+        "@polymer/neon-animation": "^3.0.0-pre.26",
+        "@polymer/paper-dialog-behavior": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/paper-dialog-behavior": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/iron-overlay-behavior": "^3.0.0-pre.27",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/paper-dialog-scrollable": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/paper-dialog-scrollable/-/paper-dialog-scrollable-3.0.1.tgz",
+      "integrity": "sha512-1E8B9kNdL58jUrJ/BwqJeOoNVcxNrB559z//d1V0rVHWT5bWCCZegwS3G06iFK5MjxWFbIKzleVTLrT0opiZkA==",
+      "requires": {
+        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
+        "@polymer/paper-dialog-behavior": "^3.0.0-pre.26",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/paper-dropdown-menu": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-form-element-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-icon": "^3.0.0-pre.26",
+        "@polymer/iron-iconset-svg": "^3.0.0-pre.26",
+        "@polymer/iron-validatable-behavior": "^3.0.0-pre.26",
+        "@polymer/paper-behaviors": "^3.0.0-pre.27",
+        "@polymer/paper-input": "^3.0.0-pre.26",
+        "@polymer/paper-menu-button": "^3.0.0-pre.26",
+        "@polymer/paper-ripple": "^3.0.0-pre.26",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/paper-icon-button": {
+      "version": "3.0.2",
+      "requires": {
+        "@polymer/iron-icon": "^3.0.0-pre.26",
+        "@polymer/paper-behaviors": "^3.0.0-pre.27",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/paper-input": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-autogrow-textarea": "^3.0.0-pre.26",
+        "@polymer/iron-behaviors": "^3.0.0-pre.26",
+        "@polymer/iron-form-element-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-input": "^3.0.0-pre.26",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/paper-item": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/iron-behaviors": "^3.0.0-pre.26",
+        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/paper-listbox": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/iron-behaviors": "^3.0.0-pre.26",
+        "@polymer/iron-menu-behavior": "^3.0.0-pre.26",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/paper-menu-button": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-behaviors": "^3.0.0-pre.26",
+        "@polymer/iron-dropdown": "^3.0.0-pre.26",
+        "@polymer/iron-fit-behavior": "^3.0.0-pre.26",
+        "@polymer/neon-animation": "^3.0.0-pre.26",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/paper-ripple": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/paper-spinner": {
+      "version": "3.0.2",
+      "requires": {
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/paper-styles": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/font-roboto": "^3.0.1",
+        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/paper-tabs": {
+      "version": "3.1.0",
+      "requires": {
+        "@polymer/iron-behaviors": "^3.0.0-pre.26",
+        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
+        "@polymer/iron-icon": "^3.0.0-pre.26",
+        "@polymer/iron-iconset-svg": "^3.0.0-pre.26",
+        "@polymer/iron-menu-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-resizable-behavior": "^3.0.0-pre.26",
+        "@polymer/paper-behaviors": "^3.0.0-pre.27",
+        "@polymer/paper-icon-button": "^3.0.0-pre.26",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/paper-toast": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/paper-toast/-/paper-toast-3.0.1.tgz",
+      "integrity": "sha512-pizuogzObniDdICUc6dSLrnDt2VzzoRne1gCmbD6sfOATVv5tc8UfrqhA2iHngbNBEbniBiciS3iogdp5KTVUQ==",
+      "requires": {
+        "@polymer/iron-a11y-announcer": "^3.0.0-pre.26",
+        "@polymer/iron-fit-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-overlay-behavior": "^3.0.0-pre.27",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/paper-toggle-button": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/paper-toggle-button/-/paper-toggle-button-3.0.1.tgz",
+      "integrity": "sha512-jadZB60fycT7YnSAH0H23LYo6/2HYmMZTtNr9LpdSIRFPLX6mqqxewex92cFz019bMKaRJgORn308hRlJo2u6A==",
+      "requires": {
+        "@polymer/iron-checked-element-behavior": "^3.0.0-pre.26",
+        "@polymer/paper-behaviors": "^3.0.0-pre.27",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/paper-tooltip": {
+      "version": "3.0.1",
+      "requires": {
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/polymer": {
+      "version": "3.2.0",
+      "requires": {
+        "@webcomponents/shadycss": "^1.8.0"
+      }
+    },
+    "@polymer/sinonjs": {
+      "version": "1.17.1",
+      "dev": true
+    },
+    "@polymer/test-fixture": {
+      "version": "3.0.0-pre.21",
+      "dev": true
+    },
+    "@webcomponents/shadycss": {
+      "version": "1.9.0"
+    },
+    "@webcomponents/webcomponentsjs": {
+      "version": "2.2.7"
+    },
+    "accessibility-developer-tools": {
+      "version": "2.12.0",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "dev": true
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "dev": true
+    },
+    "async": {
+      "version": "1.5.2",
+      "dev": true
+    },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "optional": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "devOptional": true,
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "devOptional": true
+        }
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "dev": true
+    },
+    "chai": {
+      "version": "3.5.0",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.0.1",
+        "deep-eql": "^0.1.3",
+        "type-detect": "^1.0.0"
+      }
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "2.0.0",
+          "dev": true
+        }
+      }
+    },
+    "commander": {
+      "version": "2.9.0",
+      "dev": true,
+      "requires": {
+        "graceful-readlink": ">= 1.0.0"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "dev": true
+    },
+    "core-js": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+      "devOptional": true
+    },
+    "debug": {
+      "version": "2.6.8",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-eql": {
+      "version": "0.1.3",
+      "dev": true,
+      "requires": {
+        "type-detect": "0.1.1"
+      },
+      "dependencies": {
+        "type-detect": {
+          "version": "0.1.1",
+          "dev": true
+        }
+      }
+    },
+    "diff": {
+      "version": "3.2.0",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "dev": true
+    },
+    "formatio": {
+      "version": "1.1.1",
+      "dev": true,
+      "requires": {
+        "samsam": "~1.1"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.1",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.2",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.9.2",
+      "dev": true
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "dev": true
+    },
+    "json3": {
+      "version": "3.3.2",
+      "dev": true
+    },
+    "jsrsasign": {
+      "version": "8.0.24",
+      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-8.0.24.tgz",
+      "integrity": "sha512-u45jAyusqUpyGbFc2IbHoeE4rSkoBWQgLe/w99temHenX+GyCz4nflU5sjK7ajU1ffZTezl6le7u43Yjr/lkQg=="
+    },
+    "las2peer-frontend-statusbar": {
+      "version": "git+ssh://git@github.com/rwth-acis/las2peer-frontend-statusbar.git#b969a8d05c208e6702bf650e5d6b6b3b42980890",
+      "from": "las2peer-frontend-statusbar@github:rwth-acis/las2peer-frontend-statusbar#0.3.1",
+      "requires": {
+        "@polymer/lit-element": "^0.6.3",
+        "las2peer-frontend-user-widget": "github:rwth-acis/las2peer-frontend-user-widget#0.3.0",
+        "openidconnect-signin": "github:rwth-acis/openidconnect-signin"
+      }
+    },
+    "las2peer-frontend-user-widget": {
+      "version": "git+ssh://git@github.com/rwth-acis/las2peer-frontend-user-widget.git#63ad251f95b323938b78e0d68b14ec67a1a05511",
+      "from": "las2peer-frontend-user-widget@github:rwth-acis/las2peer-frontend-user-widget#0.3.0",
+      "requires": {
+        "@polymer/iron-ajax": "^3.0.1",
+        "@polymer/iron-dropdown": "^3.0.1",
+        "@polymer/iron-flex-layout": "^3.0.1",
+        "@polymer/iron-form": "^3.0.1",
+        "@polymer/iron-icon": "^3.0.1",
+        "@polymer/iron-icons": "^3.0.1",
+        "@polymer/iron-list": "^3.0.1",
+        "@polymer/paper-badge": "^3.0.1",
+        "@polymer/paper-button": "^3.0.1",
+        "@polymer/paper-card": "^3.0.1",
+        "@polymer/paper-dialog": "^3.0.1",
+        "@polymer/paper-dialog-scrollable": "^3.0.1",
+        "@polymer/paper-dropdown-menu": "^3.0.1",
+        "@polymer/paper-icon-button": "^3.0.1",
+        "@polymer/paper-input": "^3.0.1",
+        "@polymer/paper-item": "^3.0.1",
+        "@polymer/paper-spinner": "^3.0.1",
+        "@polymer/paper-styles": "^3.0.1",
+        "@polymer/paper-toast": "^3.0.1",
+        "@polymer/paper-toggle-button": "^3.0.1",
+        "@webcomponents/webcomponentsjs": "^2.2.1"
+      }
+    },
+    "lit-element": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.5.1.tgz",
+      "integrity": "sha512-ogu7PiJTA33bEK0xGu1dmaX5vhcRjBXCFexPja0e7P7jqLhTpNKYRPmE+GmiCaRVAbiQKGkUgkh/i6+bh++dPQ==",
+      "requires": {
+        "lit-html": "^1.1.1"
+      }
+    },
+    "lit-html": {
+      "version": "1.3.0"
+    },
+    "lodash": {
+      "version": "3.10.1",
+      "dev": true
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
+      }
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "dev": true
+    },
+    "lodash._basecreate": {
+      "version": "3.0.3",
+      "dev": true
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "dev": true
+    },
+    "lodash.create": {
+      "version": "3.1.1",
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basecreate": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
+      }
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
+    },
+    "lolex": {
+      "version": "1.3.2",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "3.5.3",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.8",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "he": "1.1.1",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "dev": true
+    },
+    "oidc-client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/oidc-client/-/oidc-client-1.6.1.tgz",
+      "integrity": "sha512-buA9G0hlFjUwxoL/xuHunBtTgoICtJSojnZtATqMliUTKxPYAzHprOQ85Lj0hgF+Zv8lI/ViqaNFDG0Z5KCUKA==",
+      "requires": {
+        "babel-polyfill": ">=6.9.1",
+        "jsrsasign": "^8.0.12"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "openidconnect-signin": {
+      "version": "git+ssh://git@github.com/rwth-acis/openidconnect-signin.git#e9167a965acacfa3e686eb6d78a59e4b863939b4",
+      "from": "openidconnect-signin@github:rwth-acis/openidconnect-signin",
+      "requires": {
+        "lit-element": "^2.0.0",
+        "oidc-client": "1.6.1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "dev": true
+    },
+    "polymer-cli": {
+      "version": "1.9.7",
+      "dev": true,
+      "requires": {
+        "@octokit/rest": "^16.2.0",
+        "@types/chalk": "^0.4.31",
+        "@types/del": "^3.0.0",
+        "@types/findup-sync": "^0.3.29",
+        "@types/globby": "^6.1.0",
+        "@types/inquirer": "0.0.32",
+        "@types/merge-stream": "^1.0.28",
+        "@types/mz": "^0.0.31",
+        "@types/request": "2.0.3",
+        "@types/resolve": "0.0.4",
+        "@types/rimraf": "^0.0.28",
+        "@types/semver": "^5.3.30",
+        "@types/temp": "^0.8.28",
+        "@types/update-notifier": "^1.0.0",
+        "@types/vinyl": "^2.0.0",
+        "@types/vinyl-fs": "0.0.28",
+        "@types/yeoman-generator": "^2.0.3",
+        "bower": "^1.8.2",
+        "bower-json": "^0.8.1",
+        "bower-logger": "^0.2.2",
+        "chalk": "^1.1.3",
+        "chokidar": "^1.7.0",
+        "command-line-args": "^5.0.2",
+        "command-line-commands": "^2.0.1",
+        "command-line-usage": "^5.0.5",
+        "del": "^3.0.0",
+        "findup-sync": "^0.4.2",
+        "globby": "^8.0.1",
+        "gunzip-maybe": "^1.3.1",
+        "inquirer": "^1.0.2",
+        "merge-stream": "^1.0.1",
+        "mz": "^2.6.0",
+        "plylog": "^1.0.0",
+        "polymer-analyzer": "^3.2.2",
+        "polymer-build": "^3.1.2",
+        "polymer-bundler": "^4.0.9",
+        "polymer-linter": "^3.0.0",
+        "polymer-project-config": "^4.0.3",
+        "polyserve": "^0.27.15",
+        "request": "^2.72.0",
+        "rimraf": "^2.6.1",
+        "semver": "^5.3.0",
+        "tar-fs": "^1.12.0",
+        "temp": "^0.8.3",
+        "update-notifier": "^1.0.0",
+        "validate-element-name": "^2.1.1",
+        "vinyl": "^1.1.1",
+        "vinyl-fs": "^2.4.3",
+        "web-component-tester": "^6.9.0",
+        "yeoman-environment": "^1.5.2",
+        "yeoman-generator": "^3.1.1"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.0.0"
+          }
+        },
+        "@babel/core": {
+          "version": "7.3.4",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/generator": "^7.3.4",
+            "@babel/helpers": "^7.2.0",
+            "@babel/parser": "^7.3.4",
+            "@babel/template": "^7.2.2",
+            "@babel/traverse": "^7.3.4",
+            "@babel/types": "^7.3.4",
+            "convert-source-map": "^1.1.0",
+            "debug": "^4.1.0",
+            "json5": "^2.1.0",
+            "lodash": "^4.17.11",
+            "resolve": "^1.3.2",
+            "semver": "^5.4.1",
+            "source-map": "^0.5.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.1.1",
+              "dev": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "ms": {
+              "version": "2.1.1",
+              "dev": true
+            }
+          }
+        },
+        "@babel/generator": {
+          "version": "7.3.4",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.3.4",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.11",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          }
+        },
+        "@babel/helper-annotate-as-pure": {
+          "version": "7.0.0",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-builder-binary-assignment-operator-visitor": {
+          "version": "7.1.0",
+          "dev": true,
+          "requires": {
+            "@babel/helper-explode-assignable-expression": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-call-delegate": {
+          "version": "7.1.0",
+          "dev": true,
+          "requires": {
+            "@babel/helper-hoist-variables": "^7.0.0",
+            "@babel/traverse": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-define-map": {
+          "version": "7.1.0",
+          "dev": true,
+          "requires": {
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/types": "^7.0.0",
+            "lodash": "^4.17.10"
+          }
+        },
+        "@babel/helper-explode-assignable-expression": {
+          "version": "7.1.0",
+          "dev": true,
+          "requires": {
+            "@babel/traverse": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.1.0",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.0.0",
+            "@babel/template": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.0.0",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-hoist-variables": {
+          "version": "7.0.0",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-member-expression-to-functions": {
+          "version": "7.0.0",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-module-imports": {
+          "version": "7.0.0",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-module-transforms": {
+          "version": "7.2.2",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.0.0",
+            "@babel/helper-simple-access": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.0.0",
+            "@babel/template": "^7.2.2",
+            "@babel/types": "^7.2.2",
+            "lodash": "^4.17.10"
+          }
+        },
+        "@babel/helper-optimise-call-expression": {
+          "version": "7.0.0",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0",
+          "dev": true
+        },
+        "@babel/helper-regex": {
+          "version": "7.0.0",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.10"
+          }
+        },
+        "@babel/helper-remap-async-to-generator": {
+          "version": "7.1.0",
+          "dev": true,
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.0.0",
+            "@babel/helper-wrap-function": "^7.1.0",
+            "@babel/template": "^7.1.0",
+            "@babel/traverse": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-replace-supers": {
+          "version": "7.3.4",
+          "dev": true,
+          "requires": {
+            "@babel/helper-member-expression-to-functions": "^7.0.0",
+            "@babel/helper-optimise-call-expression": "^7.0.0",
+            "@babel/traverse": "^7.3.4",
+            "@babel/types": "^7.3.4"
+          }
+        },
+        "@babel/helper-simple-access": {
+          "version": "7.1.0",
+          "dev": true,
+          "requires": {
+            "@babel/template": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.0.0",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-wrap-function": {
+          "version": "7.2.0",
+          "dev": true,
+          "requires": {
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/template": "^7.1.0",
+            "@babel/traverse": "^7.1.0",
+            "@babel/types": "^7.2.0"
+          }
+        },
+        "@babel/helpers": {
+          "version": "7.3.1",
+          "dev": true,
+          "requires": {
+            "@babel/template": "^7.1.2",
+            "@babel/traverse": "^7.1.5",
+            "@babel/types": "^7.3.0"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "3.2.1",
+              "dev": true,
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "@babel/parser": {
+          "version": "7.3.4",
+          "dev": true
+        },
+        "@babel/plugin-external-helpers": {
+          "version": "7.2.0",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-proposal-async-generator-functions": {
+          "version": "7.2.0",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-remap-async-to-generator": "^7.1.0",
+            "@babel/plugin-syntax-async-generators": "^7.2.0"
+          }
+        },
+        "@babel/plugin-proposal-object-rest-spread": {
+          "version": "7.3.4",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-syntax-object-rest-spread": "^7.2.0"
+          }
+        },
+        "@babel/plugin-syntax-async-generators": {
+          "version": "7.2.0",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-syntax-dynamic-import": {
+          "version": "7.2.0",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-syntax-import-meta": {
+          "version": "7.2.0",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-syntax-object-rest-spread": {
+          "version": "7.2.0",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-arrow-functions": {
+          "version": "7.2.0",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-async-to-generator": {
+          "version": "7.3.4",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-remap-async-to-generator": "^7.1.0"
+          }
+        },
+        "@babel/plugin-transform-block-scoped-functions": {
+          "version": "7.2.0",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-block-scoping": {
+          "version": "7.3.4",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "lodash": "^4.17.11"
+          }
+        },
+        "@babel/plugin-transform-classes": {
+          "version": "7.3.4",
+          "dev": true,
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.0.0",
+            "@babel/helper-define-map": "^7.1.0",
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-optimise-call-expression": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-replace-supers": "^7.3.4",
+            "@babel/helper-split-export-declaration": "^7.0.0",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/plugin-transform-computed-properties": {
+          "version": "7.2.0",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-destructuring": {
+          "version": "7.3.2",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-duplicate-keys": {
+          "version": "7.2.0",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-exponentiation-operator": {
+          "version": "7.2.0",
+          "dev": true,
+          "requires": {
+            "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-for-of": {
+          "version": "7.2.0",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-function-name": {
+          "version": "7.2.0",
+          "dev": true,
+          "requires": {
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-instanceof": {
+          "version": "7.2.0",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-literals": {
+          "version": "7.2.0",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-modules-amd": {
+          "version": "7.2.0",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-transforms": "^7.1.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-object-super": {
+          "version": "7.2.0",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-replace-supers": "^7.1.0"
+          }
+        },
+        "@babel/plugin-transform-parameters": {
+          "version": "7.3.3",
+          "dev": true,
+          "requires": {
+            "@babel/helper-call-delegate": "^7.1.0",
+            "@babel/helper-get-function-arity": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-regenerator": {
+          "version": "7.3.4",
+          "dev": true,
+          "requires": {
+            "regenerator-transform": "^0.13.4"
+          }
+        },
+        "@babel/plugin-transform-shorthand-properties": {
+          "version": "7.2.0",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-spread": {
+          "version": "7.2.2",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-sticky-regex": {
+          "version": "7.2.0",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-regex": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-template-literals": {
+          "version": "7.2.0",
+          "dev": true,
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-typeof-symbol": {
+          "version": "7.2.0",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-unicode-regex": {
+          "version": "7.2.0",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-regex": "^7.0.0",
+            "regexpu-core": "^4.1.3"
+          }
+        },
+        "@babel/template": {
+          "version": "7.2.2",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/parser": "^7.2.2",
+            "@babel/types": "^7.2.2"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.3.4",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/generator": "^7.3.4",
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.0.0",
+            "@babel/parser": "^7.3.4",
+            "@babel/types": "^7.3.4",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.11"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.1.1",
+              "dev": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "ms": {
+              "version": "2.1.1",
+              "dev": true
+            }
+          }
+        },
+        "@babel/types": {
+          "version": "7.3.4",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "@mrmlnc/readdir-enhanced": {
+          "version": "2.2.1",
+          "dev": true,
+          "requires": {
+            "call-me-maybe": "^1.0.1",
+            "glob-to-regexp": "^0.3.0"
+          }
+        },
+        "@nodelib/fs.stat": {
+          "version": "1.1.3",
+          "dev": true
+        },
+        "@octokit/endpoint": {
+          "version": "3.1.3",
+          "dev": true,
+          "requires": {
+            "deepmerge": "3.2.0",
+            "is-plain-object": "^2.0.4",
+            "universal-user-agent": "^2.0.1",
+            "url-template": "^2.0.8"
+          }
+        },
+        "@octokit/request": {
+          "version": "2.4.0",
+          "dev": true,
+          "requires": {
+            "@octokit/endpoint": "^3.1.1",
+            "is-plain-object": "^2.0.4",
+            "node-fetch": "^2.3.0",
+            "universal-user-agent": "^2.0.1"
+          }
+        },
+        "@octokit/rest": {
+          "version": "16.16.3",
+          "dev": true,
+          "requires": {
+            "@octokit/request": "2.4.0",
+            "before-after-hook": "^1.2.0",
+            "btoa-lite": "^1.0.0",
+            "lodash.get": "^4.4.2",
+            "lodash.set": "^4.3.2",
+            "lodash.uniq": "^4.5.0",
+            "octokit-pagination-methods": "^1.1.0",
+            "universal-user-agent": "^2.0.0",
+            "url-template": "^2.0.8"
+          }
+        },
+        "@polymer/esm-amd-loader": {
+          "version": "1.0.4",
+          "dev": true
+        },
+        "@polymer/sinonjs": {
+          "version": "1.17.1",
+          "dev": true
+        },
+        "@polymer/test-fixture": {
+          "version": "0.0.3",
+          "dev": true
+        },
+        "@types/babel-generator": {
+          "version": "6.25.3",
+          "dev": true,
+          "requires": {
+            "@types/babel-types": "*"
+          }
+        },
+        "@types/babel-traverse": {
+          "version": "6.25.5",
+          "dev": true,
+          "requires": {
+            "@types/babel-types": "*"
+          }
+        },
+        "@types/babel-types": {
+          "version": "6.25.2",
+          "dev": true
+        },
+        "@types/babylon": {
+          "version": "6.16.5",
+          "dev": true,
+          "requires": {
+            "@types/babel-types": "*"
+          }
+        },
+        "@types/bluebird": {
+          "version": "3.5.26",
+          "dev": true
+        },
+        "@types/body-parser": {
+          "version": "1.17.0",
+          "dev": true,
+          "requires": {
+            "@types/connect": "*",
+            "@types/node": "*"
+          }
+        },
+        "@types/chai": {
+          "version": "4.1.7",
+          "dev": true
+        },
+        "@types/chai-subset": {
+          "version": "1.3.2",
+          "dev": true,
+          "requires": {
+            "@types/chai": "*"
+          }
+        },
+        "@types/chalk": {
+          "version": "0.4.31",
+          "dev": true
+        },
+        "@types/clean-css": {
+          "version": "4.2.0",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/clone": {
+          "version": "0.1.30",
+          "dev": true
+        },
+        "@types/compression": {
+          "version": "0.0.33",
+          "dev": true,
+          "requires": {
+            "@types/express": "*"
+          }
+        },
+        "@types/connect": {
+          "version": "3.4.32",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/content-type": {
+          "version": "1.1.3",
+          "dev": true
+        },
+        "@types/cssbeautify": {
+          "version": "0.3.1",
+          "dev": true
+        },
+        "@types/del": {
+          "version": "3.0.1",
+          "dev": true,
+          "requires": {
+            "@types/glob": "*"
+          }
+        },
+        "@types/doctrine": {
+          "version": "0.0.1",
+          "dev": true
+        },
+        "@types/escape-html": {
+          "version": "0.0.20",
+          "dev": true
+        },
+        "@types/estree": {
+          "version": "0.0.39",
+          "dev": true
+        },
+        "@types/events": {
+          "version": "3.0.0",
+          "dev": true
+        },
+        "@types/express": {
+          "version": "4.16.1",
+          "dev": true,
+          "requires": {
+            "@types/body-parser": "*",
+            "@types/express-serve-static-core": "*",
+            "@types/serve-static": "*"
+          }
+        },
+        "@types/express-serve-static-core": {
+          "version": "4.16.1",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "@types/range-parser": "*"
+          }
+        },
+        "@types/fast-levenshtein": {
+          "version": "0.0.1",
+          "dev": true
+        },
+        "@types/findup-sync": {
+          "version": "0.3.30",
+          "dev": true,
+          "requires": {
+            "@types/minimatch": "*"
+          }
+        },
+        "@types/form-data": {
+          "version": "2.2.1",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/freeport": {
+          "version": "1.0.21",
+          "dev": true,
+          "optional": true
+        },
+        "@types/glob": {
+          "version": "7.1.1",
+          "dev": true,
+          "requires": {
+            "@types/events": "*",
+            "@types/minimatch": "*",
+            "@types/node": "*"
+          }
+        },
+        "@types/glob-stream": {
+          "version": "6.1.0",
+          "dev": true,
+          "requires": {
+            "@types/glob": "*",
+            "@types/node": "*"
+          }
+        },
+        "@types/globby": {
+          "version": "6.1.0",
+          "dev": true,
+          "requires": {
+            "@types/glob": "*"
+          }
+        },
+        "@types/gulp-if": {
+          "version": "0.0.33",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "@types/vinyl": "*"
+          }
+        },
+        "@types/html-minifier": {
+          "version": "3.5.3",
+          "dev": true,
+          "requires": {
+            "@types/clean-css": "*",
+            "@types/relateurl": "*",
+            "@types/uglify-js": "*"
+          }
+        },
+        "@types/inquirer": {
+          "version": "0.0.32",
+          "dev": true,
+          "requires": {
+            "@types/rx": "*",
+            "@types/through": "*"
+          }
+        },
+        "@types/is-windows": {
+          "version": "0.2.0",
+          "dev": true
+        },
+        "@types/launchpad": {
+          "version": "0.6.0",
+          "dev": true,
+          "optional": true
+        },
+        "@types/merge-stream": {
+          "version": "1.1.2",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/mime": {
+          "version": "2.0.1",
+          "dev": true
+        },
+        "@types/minimatch": {
+          "version": "3.0.3",
+          "dev": true
+        },
+        "@types/mz": {
+          "version": "0.0.31",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/node": {
+          "version": "11.10.1",
+          "dev": true
+        },
+        "@types/opn": {
+          "version": "3.0.28",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/parse5": {
+          "version": "2.2.34",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/path-is-inside": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "@types/pem": {
+          "version": "1.9.5",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/range-parser": {
+          "version": "1.2.3",
+          "dev": true
+        },
+        "@types/relateurl": {
+          "version": "0.2.28",
+          "dev": true
+        },
+        "@types/request": {
+          "version": "2.0.3",
+          "dev": true,
+          "requires": {
+            "@types/form-data": "*",
+            "@types/node": "*"
+          }
+        },
+        "@types/resolve": {
+          "version": "0.0.4",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/rimraf": {
+          "version": "0.0.28",
+          "dev": true
+        },
+        "@types/rx": {
+          "version": "4.1.1",
+          "dev": true,
+          "requires": {
+            "@types/rx-core": "*",
+            "@types/rx-core-binding": "*",
+            "@types/rx-lite": "*",
+            "@types/rx-lite-aggregates": "*",
+            "@types/rx-lite-async": "*",
+            "@types/rx-lite-backpressure": "*",
+            "@types/rx-lite-coincidence": "*",
+            "@types/rx-lite-experimental": "*",
+            "@types/rx-lite-joinpatterns": "*",
+            "@types/rx-lite-testing": "*",
+            "@types/rx-lite-time": "*",
+            "@types/rx-lite-virtualtime": "*"
+          }
+        },
+        "@types/rx-core": {
+          "version": "4.0.3",
+          "dev": true
+        },
+        "@types/rx-core-binding": {
+          "version": "4.0.4",
+          "dev": true,
+          "requires": {
+            "@types/rx-core": "*"
+          }
+        },
+        "@types/rx-lite": {
+          "version": "4.0.6",
+          "dev": true,
+          "requires": {
+            "@types/rx-core": "*",
+            "@types/rx-core-binding": "*"
+          }
+        },
+        "@types/rx-lite-aggregates": {
+          "version": "4.0.3",
+          "dev": true,
+          "requires": {
+            "@types/rx-lite": "*"
+          }
+        },
+        "@types/rx-lite-async": {
+          "version": "4.0.2",
+          "dev": true,
+          "requires": {
+            "@types/rx-lite": "*"
+          }
+        },
+        "@types/rx-lite-backpressure": {
+          "version": "4.0.3",
+          "dev": true,
+          "requires": {
+            "@types/rx-lite": "*"
+          }
+        },
+        "@types/rx-lite-coincidence": {
+          "version": "4.0.3",
+          "dev": true,
+          "requires": {
+            "@types/rx-lite": "*"
+          }
+        },
+        "@types/rx-lite-experimental": {
+          "version": "4.0.1",
+          "dev": true,
+          "requires": {
+            "@types/rx-lite": "*"
+          }
+        },
+        "@types/rx-lite-joinpatterns": {
+          "version": "4.0.1",
+          "dev": true,
+          "requires": {
+            "@types/rx-lite": "*"
+          }
+        },
+        "@types/rx-lite-testing": {
+          "version": "4.0.1",
+          "dev": true,
+          "requires": {
+            "@types/rx-lite-virtualtime": "*"
+          }
+        },
+        "@types/rx-lite-time": {
+          "version": "4.0.3",
+          "dev": true,
+          "requires": {
+            "@types/rx-lite": "*"
+          }
+        },
+        "@types/rx-lite-virtualtime": {
+          "version": "4.0.3",
+          "dev": true,
+          "requires": {
+            "@types/rx-lite": "*"
+          }
+        },
+        "@types/semver": {
+          "version": "5.5.0",
+          "dev": true
+        },
+        "@types/serve-static": {
+          "version": "1.13.2",
+          "dev": true,
+          "requires": {
+            "@types/express-serve-static-core": "*",
+            "@types/mime": "*"
+          }
+        },
+        "@types/spdy": {
+          "version": "3.4.4",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/temp": {
+          "version": "0.8.33",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/through": {
+          "version": "0.0.29",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/ua-parser-js": {
+          "version": "0.7.32",
+          "dev": true
+        },
+        "@types/uglify-js": {
+          "version": "3.0.4",
+          "dev": true,
+          "requires": {
+            "source-map": "^0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "dev": true
+            }
+          }
+        },
+        "@types/update-notifier": {
+          "version": "1.0.3",
+          "dev": true
+        },
+        "@types/uuid": {
+          "version": "3.4.4",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/vinyl": {
+          "version": "2.0.2",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/vinyl-fs": {
+          "version": "0.0.28",
+          "dev": true,
+          "requires": {
+            "@types/glob-stream": "*",
+            "@types/node": "*",
+            "@types/vinyl": "*"
+          }
+        },
+        "@types/whatwg-url": {
+          "version": "6.4.0",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/which": {
+          "version": "1.3.1",
+          "dev": true,
+          "optional": true
+        },
+        "@types/yeoman-generator": {
+          "version": "2.0.3",
+          "dev": true,
+          "requires": {
+            "@types/events": "*",
+            "@types/inquirer": "*"
+          }
+        },
+        "@webcomponents/webcomponentsjs": {
+          "version": "1.3.3",
+          "dev": true
+        },
+        "accepts": {
+          "version": "1.3.5",
+          "dev": true,
+          "requires": {
+            "mime-types": "~2.1.18",
+            "negotiator": "0.6.1"
+          }
+        },
+        "accessibility-developer-tools": {
+          "version": "2.12.0",
+          "dev": true
+        },
+        "acorn": {
+          "version": "5.7.3",
+          "dev": true
+        },
+        "acorn-jsx": {
+          "version": "3.0.1",
+          "dev": true,
+          "requires": {
+            "acorn": "^3.0.4"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "3.3.0",
+              "dev": true
+            }
+          }
+        },
+        "adm-zip": {
+          "version": "0.4.13",
+          "dev": true,
+          "optional": true
+        },
+        "after": {
+          "version": "0.8.2",
+          "dev": true
+        },
+        "agent-base": {
+          "version": "4.2.1",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "es6-promisify": "^5.0.0"
+          },
+          "dependencies": {
+            "es6-promisify": {
+              "version": "5.0.0",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "es6-promise": "^4.0.3"
+              }
+            }
+          }
+        },
+        "ajv": {
+          "version": "6.9.2",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ansi-align": {
+          "version": "2.0.0",
+          "dev": true,
+          "requires": {
+            "string-width": "^2.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "dev": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "dev": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "ansi-escapes": {
+          "version": "1.4.0",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "dev": true
+        },
+        "any-promise": {
+          "version": "1.3.0",
+          "dev": true
+        },
+        "anymatch": {
+          "version": "1.3.2",
+          "dev": true,
+          "requires": {
+            "micromatch": "^2.1.5",
+            "normalize-path": "^2.0.0"
+          }
+        },
+        "append-field": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "archiver": {
+          "version": "2.1.1",
+          "dev": true,
+          "requires": {
+            "archiver-utils": "^1.3.0",
+            "async": "^2.0.0",
+            "buffer-crc32": "^0.2.1",
+            "glob": "^7.0.0",
+            "lodash": "^4.8.0",
+            "readable-stream": "^2.0.0",
+            "tar-stream": "^1.5.0",
+            "zip-stream": "^1.2.0"
+          }
+        },
+        "archiver-utils": {
+          "version": "1.3.0",
+          "dev": true,
+          "requires": {
+            "glob": "^7.0.0",
+            "graceful-fs": "^4.1.0",
+            "lazystream": "^1.0.0",
+            "lodash": "^4.8.0",
+            "normalize-path": "^2.0.0",
+            "readable-stream": "^2.0.0"
+          }
+        },
+        "argv-tools": {
+          "version": "0.1.1",
+          "dev": true,
+          "requires": {
+            "array-back": "^2.0.0",
+            "find-replace": "^2.0.1"
+          }
+        },
+        "arr-diff": {
+          "version": "2.0.0",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.0.1"
+          }
+        },
+        "arr-flatten": {
+          "version": "1.1.0",
+          "dev": true
+        },
+        "arr-union": {
+          "version": "3.1.0",
+          "dev": true
+        },
+        "array-back": {
+          "version": "2.0.0",
+          "dev": true,
+          "requires": {
+            "typical": "^2.6.1"
+          }
+        },
+        "array-differ": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "array-find-index": {
+          "version": "1.0.2",
+          "dev": true
+        },
+        "array-flatten": {
+          "version": "1.1.1",
+          "dev": true
+        },
+        "array-union": {
+          "version": "1.0.2",
+          "dev": true,
+          "requires": {
+            "array-uniq": "^1.0.1"
+          }
+        },
+        "array-uniq": {
+          "version": "1.0.3",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "dev": true
+        },
+        "arraybuffer.slice": {
+          "version": "0.0.7",
+          "dev": true
+        },
+        "arrify": {
+          "version": "1.0.1",
+          "dev": true
+        },
+        "asn1": {
+          "version": "0.2.4",
+          "dev": true,
+          "requires": {
+            "safer-buffer": "~2.1.0"
+          }
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "assign-symbols": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "async": {
+          "version": "2.6.2",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.11"
+          }
+        },
+        "async-each": {
+          "version": "1.0.1",
+          "dev": true
+        },
+        "async-limiter": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "dev": true
+        },
+        "atob": {
+          "version": "2.1.2",
+          "dev": true
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "dev": true
+        },
+        "aws4": {
+          "version": "1.8.0",
+          "dev": true
+        },
+        "babel-code-frame": {
+          "version": "6.26.0",
+          "dev": true,
+          "requires": {
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
+          },
+          "dependencies": {
+            "js-tokens": {
+              "version": "3.0.2",
+              "dev": true
+            }
+          }
+        },
+        "babel-generator": {
+          "version": "6.26.1",
+          "dev": true,
+          "requires": {
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "detect-indent": "^4.0.0",
+            "jsesc": "^1.3.0",
+            "lodash": "^4.17.4",
+            "source-map": "^0.5.7",
+            "trim-right": "^1.0.1"
+          },
+          "dependencies": {
+            "jsesc": {
+              "version": "1.3.0",
+              "dev": true
+            }
+          }
+        },
+        "babel-helper-evaluate-path": {
+          "version": "0.4.3",
+          "dev": true
+        },
+        "babel-helper-flip-expressions": {
+          "version": "0.4.3",
+          "dev": true
+        },
+        "babel-helper-is-nodes-equiv": {
+          "version": "0.0.1",
+          "dev": true
+        },
+        "babel-helper-is-void-0": {
+          "version": "0.4.3",
+          "dev": true
+        },
+        "babel-helper-mark-eval-scopes": {
+          "version": "0.4.3",
+          "dev": true
+        },
+        "babel-helper-remove-or-void": {
+          "version": "0.4.3",
+          "dev": true
+        },
+        "babel-helper-to-multiple-sequence-expressions": {
+          "version": "0.4.3",
+          "dev": true
+        },
+        "babel-messages": {
+          "version": "6.23.0",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-minify-builtins": {
+          "version": "0.4.3",
+          "dev": true,
+          "requires": {
+            "babel-helper-evaluate-path": "^0.4.3"
+          }
+        },
+        "babel-plugin-minify-constant-folding": {
+          "version": "0.4.3",
+          "dev": true,
+          "requires": {
+            "babel-helper-evaluate-path": "^0.4.3"
+          }
+        },
+        "babel-plugin-minify-dead-code-elimination": {
+          "version": "0.4.3",
+          "dev": true,
+          "requires": {
+            "babel-helper-evaluate-path": "^0.4.3",
+            "babel-helper-mark-eval-scopes": "^0.4.3",
+            "babel-helper-remove-or-void": "^0.4.3",
+            "lodash.some": "^4.6.0"
+          }
+        },
+        "babel-plugin-minify-flip-comparisons": {
+          "version": "0.4.3",
+          "dev": true,
+          "requires": {
+            "babel-helper-is-void-0": "^0.4.3"
+          }
+        },
+        "babel-plugin-minify-guarded-expressions": {
+          "version": "0.4.1",
+          "dev": true,
+          "requires": {
+            "babel-helper-flip-expressions": "^0.4.1"
+          }
+        },
+        "babel-plugin-minify-infinity": {
+          "version": "0.4.3",
+          "dev": true
+        },
+        "babel-plugin-minify-mangle-names": {
+          "version": "0.4.3",
+          "dev": true,
+          "requires": {
+            "babel-helper-mark-eval-scopes": "^0.4.3"
+          }
+        },
+        "babel-plugin-minify-numeric-literals": {
+          "version": "0.4.3",
+          "dev": true
+        },
+        "babel-plugin-minify-replace": {
+          "version": "0.4.3",
+          "dev": true
+        },
+        "babel-plugin-minify-simplify": {
+          "version": "0.4.3",
+          "dev": true,
+          "requires": {
+            "babel-helper-flip-expressions": "^0.4.3",
+            "babel-helper-is-nodes-equiv": "^0.0.1",
+            "babel-helper-to-multiple-sequence-expressions": "^0.4.3"
+          }
+        },
+        "babel-plugin-minify-type-constructors": {
+          "version": "0.4.3",
+          "dev": true,
+          "requires": {
+            "babel-helper-is-void-0": "^0.4.3"
+          }
+        },
+        "babel-plugin-transform-inline-consecutive-adds": {
+          "version": "0.4.3",
+          "dev": true
+        },
+        "babel-plugin-transform-member-expression-literals": {
+          "version": "6.10.0-alpha.f95869d4",
+          "dev": true
+        },
+        "babel-plugin-transform-merge-sibling-variables": {
+          "version": "6.10.0-alpha.f95869d4",
+          "dev": true
+        },
+        "babel-plugin-transform-minify-booleans": {
+          "version": "6.10.0-alpha.f95869d4",
+          "dev": true
+        },
+        "babel-plugin-transform-property-literals": {
+          "version": "6.10.0-alpha.f95869d4",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "babel-plugin-transform-regexp-constructors": {
+          "version": "0.4.3",
+          "dev": true
+        },
+        "babel-plugin-transform-remove-console": {
+          "version": "6.10.0-alpha.f95869d4",
+          "dev": true
+        },
+        "babel-plugin-transform-remove-debugger": {
+          "version": "6.10.0-alpha.f95869d4",
+          "dev": true
+        },
+        "babel-plugin-transform-remove-undefined": {
+          "version": "0.4.3",
+          "dev": true,
+          "requires": {
+            "babel-helper-evaluate-path": "^0.4.3"
+          }
+        },
+        "babel-plugin-transform-simplify-comparison-operators": {
+          "version": "6.10.0-alpha.f95869d4",
+          "dev": true
+        },
+        "babel-plugin-transform-undefined-to-void": {
+          "version": "6.10.0-alpha.f95869d4",
+          "dev": true
+        },
+        "babel-preset-minify": {
+          "version": "0.4.0-alpha.caaefb4c",
+          "dev": true,
+          "requires": {
+            "babel-plugin-minify-builtins": "^0.4.0-alpha.caaefb4c",
+            "babel-plugin-minify-constant-folding": "^0.4.0-alpha.caaefb4c",
+            "babel-plugin-minify-dead-code-elimination": "^0.4.0-alpha.caaefb4c",
+            "babel-plugin-minify-flip-comparisons": "^0.4.0-alpha.caaefb4c",
+            "babel-plugin-minify-guarded-expressions": "^0.4.0-alpha.caaefb4c",
+            "babel-plugin-minify-infinity": "^0.4.0-alpha.caaefb4c",
+            "babel-plugin-minify-mangle-names": "^0.4.0-alpha.caaefb4c",
+            "babel-plugin-minify-numeric-literals": "^0.4.0-alpha.caaefb4c",
+            "babel-plugin-minify-replace": "^0.4.0-alpha.caaefb4c",
+            "babel-plugin-minify-simplify": "^0.4.0-alpha.caaefb4c",
+            "babel-plugin-minify-type-constructors": "^0.4.0-alpha.caaefb4c",
+            "babel-plugin-transform-inline-consecutive-adds": "^0.4.0-alpha.caaefb4c",
+            "babel-plugin-transform-member-expression-literals": "^6.10.0-alpha.caaefb4c",
+            "babel-plugin-transform-merge-sibling-variables": "^6.10.0-alpha.caaefb4c",
+            "babel-plugin-transform-minify-booleans": "^6.10.0-alpha.caaefb4c",
+            "babel-plugin-transform-property-literals": "^6.10.0-alpha.caaefb4c",
+            "babel-plugin-transform-regexp-constructors": "^0.4.0-alpha.caaefb4c",
+            "babel-plugin-transform-remove-console": "^6.10.0-alpha.caaefb4c",
+            "babel-plugin-transform-remove-debugger": "^6.10.0-alpha.caaefb4c",
+            "babel-plugin-transform-remove-undefined": "^0.4.0-alpha.caaefb4c",
+            "babel-plugin-transform-simplify-comparison-operators": "^6.10.0-alpha.caaefb4c",
+            "babel-plugin-transform-undefined-to-void": "^6.10.0-alpha.caaefb4c",
+            "lodash.isplainobject": "^4.0.6"
+          }
+        },
+        "babel-traverse": {
+          "version": "6.26.0",
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "^6.26.0",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "debug": "^2.6.8",
+            "globals": "^9.18.0",
+            "invariant": "^2.2.2",
+            "lodash": "^4.17.4"
+          },
+          "dependencies": {
+            "babylon": {
+              "version": "6.18.0",
+              "dev": true
+            },
+            "globals": {
+              "version": "9.18.0",
+              "dev": true
+            }
+          }
+        },
+        "babel-types": {
+          "version": "6.26.0",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.26.0",
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.4",
+            "to-fast-properties": "^1.0.3"
+          },
+          "dependencies": {
+            "to-fast-properties": {
+              "version": "1.0.3",
+              "dev": true
+            }
+          }
+        },
+        "babylon": {
+          "version": "7.0.0-beta.47",
+          "dev": true
+        },
+        "backo2": {
+          "version": "1.0.2",
+          "dev": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "base": {
+          "version": "0.11.2",
+          "dev": true,
+          "requires": {
+            "cache-base": "^1.0.1",
+            "class-utils": "^0.3.5",
+            "component-emitter": "^1.2.1",
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.1",
+            "mixin-deep": "^1.2.0",
+            "pascalcase": "^0.1.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "dev": true
+            }
+          }
+        },
+        "base64-arraybuffer": {
+          "version": "0.1.5",
+          "dev": true
+        },
+        "base64-js": {
+          "version": "1.2.0",
+          "dev": true
+        },
+        "base64id": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.2",
+          "dev": true,
+          "requires": {
+            "tweetnacl": "^0.14.3"
+          }
+        },
+        "before-after-hook": {
+          "version": "1.3.2",
+          "dev": true
+        },
+        "better-assert": {
+          "version": "1.0.2",
+          "dev": true,
+          "requires": {
+            "callsite": "1.0.0"
+          }
+        },
+        "binary-extensions": {
+          "version": "1.13.0",
+          "dev": true
+        },
+        "binaryextensions": {
+          "version": "2.1.2",
+          "dev": true
+        },
+        "bl": {
+          "version": "1.2.2",
+          "dev": true,
+          "requires": {
+            "readable-stream": "^2.3.5",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "blob": {
+          "version": "0.0.5",
+          "dev": true
+        },
+        "body-parser": {
+          "version": "1.18.3",
+          "dev": true,
+          "requires": {
+            "bytes": "3.0.0",
+            "content-type": "~1.0.4",
+            "debug": "2.6.9",
+            "depd": "~1.1.2",
+            "http-errors": "~1.6.3",
+            "iconv-lite": "0.4.23",
+            "on-finished": "~2.3.0",
+            "qs": "6.5.2",
+            "raw-body": "2.3.3",
+            "type-is": "~1.6.16"
+          }
+        },
+        "bower": {
+          "version": "1.8.8",
+          "dev": true
+        },
+        "bower-config": {
+          "version": "1.4.1",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.3",
+            "mout": "^1.0.0",
+            "optimist": "^0.6.1",
+            "osenv": "^0.1.3",
+            "untildify": "^2.1.0"
+          }
+        },
+        "bower-json": {
+          "version": "0.8.1",
+          "dev": true,
+          "requires": {
+            "deep-extend": "^0.4.0",
+            "ext-name": "^3.0.0",
+            "graceful-fs": "^4.1.3",
+            "intersect": "^1.0.1"
+          }
+        },
+        "bower-logger": {
+          "version": "0.2.2",
+          "dev": true
+        },
+        "boxen": {
+          "version": "1.3.0",
+          "dev": true,
+          "requires": {
+            "ansi-align": "^2.0.0",
+            "camelcase": "^4.0.0",
+            "chalk": "^2.0.1",
+            "cli-boxes": "^1.0.0",
+            "string-width": "^2.0.0",
+            "term-size": "^1.2.0",
+            "widest-line": "^2.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "dev": true
+            },
+            "ansi-styles": {
+              "version": "3.2.1",
+              "dev": true,
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "camelcase": {
+              "version": "4.1.0",
+              "dev": true
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "dev": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "dev": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "braces": {
+          "version": "1.8.5",
+          "dev": true,
+          "requires": {
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
+          }
+        },
+        "browser-capabilities": {
+          "version": "1.1.3",
+          "dev": true,
+          "requires": {
+            "@types/ua-parser-js": "^0.7.31",
+            "ua-parser-js": "^0.7.15"
+          }
+        },
+        "browserify-zlib": {
+          "version": "0.1.4",
+          "dev": true,
+          "requires": {
+            "pako": "~0.2.0"
+          }
+        },
+        "browserstack": {
+          "version": "1.5.2",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "https-proxy-agent": "^2.2.1"
+          }
+        },
+        "btoa-lite": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "buffer": {
+          "version": "5.2.1",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        },
+        "buffer-alloc": {
+          "version": "1.2.0",
+          "dev": true,
+          "requires": {
+            "buffer-alloc-unsafe": "^1.1.0",
+            "buffer-fill": "^1.0.0"
+          }
+        },
+        "buffer-alloc-unsafe": {
+          "version": "1.1.0",
+          "dev": true
+        },
+        "buffer-crc32": {
+          "version": "0.2.13",
+          "dev": true
+        },
+        "buffer-fill": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "buffer-from": {
+          "version": "1.1.1",
+          "dev": true
+        },
+        "busboy": {
+          "version": "0.2.14",
+          "dev": true,
+          "requires": {
+            "dicer": "0.2.5",
+            "readable-stream": "1.1.x"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "1.1.14",
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+              }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "dev": true
+            }
+          }
+        },
+        "bytes": {
+          "version": "3.0.0",
+          "dev": true
+        },
+        "cache-base": {
+          "version": "1.0.1",
+          "dev": true,
+          "requires": {
+            "collection-visit": "^1.0.0",
+            "component-emitter": "^1.2.1",
+            "get-value": "^2.0.6",
+            "has-value": "^1.0.0",
+            "isobject": "^3.0.1",
+            "set-value": "^2.0.0",
+            "to-object-path": "^0.3.0",
+            "union-value": "^1.0.0",
+            "unset-value": "^1.0.0"
+          }
+        },
+        "call-me-maybe": {
+          "version": "1.0.1",
+          "dev": true
+        },
+        "callsite": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "camel-case": {
+          "version": "3.0.0",
+          "dev": true,
+          "requires": {
+            "no-case": "^2.2.0",
+            "upper-case": "^1.1.1"
+          }
+        },
+        "camelcase": {
+          "version": "2.1.1",
+          "dev": true
+        },
+        "camelcase-keys": {
+          "version": "2.1.0",
+          "dev": true,
+          "requires": {
+            "camelcase": "^2.0.0",
+            "map-obj": "^1.0.0"
+          }
+        },
+        "cancel-token": {
+          "version": "0.1.1",
+          "dev": true,
+          "requires": {
+            "@types/node": "^4.0.30"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "4.9.3",
+              "dev": true
+            }
+          }
+        },
+        "capture-stack-trace": {
+          "version": "1.0.1",
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "chardet": {
+          "version": "0.7.0",
+          "dev": true
+        },
+        "charenc": {
+          "version": "0.0.2",
+          "dev": true
+        },
+        "chokidar": {
+          "version": "1.7.0",
+          "dev": true,
+          "requires": {
+            "anymatch": "^1.3.0",
+            "async-each": "^1.0.0",
+            "fsevents": "^1.0.0",
+            "glob-parent": "^2.0.0",
+            "inherits": "^2.0.1",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^2.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.0.0"
+          }
+        },
+        "chownr": {
+          "version": "1.1.1",
+          "dev": true
+        },
+        "ci-info": {
+          "version": "1.6.0",
+          "dev": true
+        },
+        "class-utils": {
+          "version": "0.3.6",
+          "dev": true,
+          "requires": {
+            "arr-union": "^3.1.0",
+            "define-property": "^0.2.5",
+            "isobject": "^3.0.0",
+            "static-extend": "^0.1.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            }
+          }
+        },
+        "clean-css": {
+          "version": "4.2.1",
+          "dev": true,
+          "requires": {
+            "source-map": "~0.6.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "dev": true
+            }
+          }
+        },
+        "cleankill": {
+          "version": "2.0.0",
+          "dev": true
+        },
+        "cli-boxes": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "cli-cursor": {
+          "version": "1.0.2",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^1.0.1"
+          }
+        },
+        "cli-table": {
+          "version": "0.3.1",
+          "dev": true,
+          "requires": {
+            "colors": "1.0.3"
+          },
+          "dependencies": {
+            "colors": {
+              "version": "1.0.3",
+              "dev": true
+            }
+          }
+        },
+        "cli-width": {
+          "version": "2.2.0",
+          "dev": true
+        },
+        "clone": {
+          "version": "2.1.2",
+          "dev": true
+        },
+        "clone-buffer": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "clone-stats": {
+          "version": "0.0.1",
+          "dev": true
+        },
+        "cloneable-readable": {
+          "version": "1.1.2",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "process-nextick-args": "^2.0.0",
+            "readable-stream": "^2.3.5"
+          }
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "dev": true
+        },
+        "collection-visit": {
+          "version": "1.0.0",
+          "dev": true,
+          "requires": {
+            "map-visit": "^1.0.0",
+            "object-visit": "^1.0.0"
+          }
+        },
+        "color": {
+          "version": "3.0.0",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.1",
+            "color-string": "^1.5.2"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "dev": true
+        },
+        "color-string": {
+          "version": "1.5.3",
+          "dev": true,
+          "requires": {
+            "color-name": "^1.0.0",
+            "simple-swizzle": "^0.2.2"
+          }
+        },
+        "colornames": {
+          "version": "1.1.1",
+          "dev": true
+        },
+        "colors": {
+          "version": "1.3.3",
+          "dev": true
+        },
+        "colorspace": {
+          "version": "1.1.1",
+          "dev": true,
+          "requires": {
+            "color": "3.0.x",
+            "text-hex": "1.0.x"
+          }
+        },
+        "combined-stream": {
+          "version": "1.0.7",
+          "dev": true,
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        },
+        "command-line-args": {
+          "version": "5.0.2",
+          "dev": true,
+          "requires": {
+            "argv-tools": "^0.1.1",
+            "array-back": "^2.0.0",
+            "find-replace": "^2.0.1",
+            "lodash.camelcase": "^4.3.0",
+            "typical": "^2.6.1"
+          }
+        },
+        "command-line-commands": {
+          "version": "2.0.1",
+          "dev": true,
+          "requires": {
+            "array-back": "^2.0.0"
+          }
+        },
+        "command-line-usage": {
+          "version": "5.0.5",
+          "dev": true,
+          "requires": {
+            "array-back": "^2.0.0",
+            "chalk": "^2.4.1",
+            "table-layout": "^0.4.3",
+            "typical": "^2.6.1"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "3.2.1",
+              "dev": true,
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "commander": {
+          "version": "2.17.1",
+          "dev": true
+        },
+        "commondir": {
+          "version": "1.0.1",
+          "dev": true
+        },
+        "component-bind": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "component-emitter": {
+          "version": "1.2.1",
+          "dev": true
+        },
+        "component-inherit": {
+          "version": "0.0.3",
+          "dev": true
+        },
+        "compress-commons": {
+          "version": "1.2.2",
+          "dev": true,
+          "requires": {
+            "buffer-crc32": "^0.2.1",
+            "crc32-stream": "^2.0.0",
+            "normalize-path": "^2.0.0",
+            "readable-stream": "^2.0.0"
+          }
+        },
+        "compressible": {
+          "version": "2.0.16",
+          "dev": true,
+          "requires": {
+            "mime-db": ">= 1.38.0 < 2"
+          }
+        },
+        "compression": {
+          "version": "1.7.3",
+          "dev": true,
+          "requires": {
+            "accepts": "~1.3.5",
+            "bytes": "3.0.0",
+            "compressible": "~2.0.14",
+            "debug": "2.6.9",
+            "on-headers": "~1.0.1",
+            "safe-buffer": "5.1.2",
+            "vary": "~1.1.2"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "dev": true
+        },
+        "concat-stream": {
+          "version": "1.6.2",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
+          }
+        },
+        "configstore": {
+          "version": "3.1.2",
+          "dev": true,
+          "requires": {
+            "dot-prop": "^4.1.0",
+            "graceful-fs": "^4.1.2",
+            "make-dir": "^1.0.0",
+            "unique-string": "^1.0.0",
+            "write-file-atomic": "^2.0.0",
+            "xdg-basedir": "^3.0.0"
+          }
+        },
+        "content-disposition": {
+          "version": "0.5.2",
+          "dev": true
+        },
+        "content-type": {
+          "version": "1.0.4",
+          "dev": true
+        },
+        "convert-source-map": {
+          "version": "1.6.0",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.1"
+          }
+        },
+        "cookie": {
+          "version": "0.3.1",
+          "dev": true
+        },
+        "cookie-signature": {
+          "version": "1.0.6",
+          "dev": true
+        },
+        "copy-descriptor": {
+          "version": "0.1.1",
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "dev": true
+        },
+        "cors": {
+          "version": "2.8.5",
+          "dev": true,
+          "requires": {
+            "object-assign": "^4",
+            "vary": "^1"
+          }
+        },
+        "crc": {
+          "version": "3.8.0",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.1.0"
+          }
+        },
+        "crc32-stream": {
+          "version": "2.0.0",
+          "dev": true,
+          "requires": {
+            "crc": "^3.4.4",
+            "readable-stream": "^2.0.0"
+          }
+        },
+        "create-error-class": {
+          "version": "3.0.2",
+          "dev": true,
+          "requires": {
+            "capture-stack-trace": "^1.0.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "crypt": {
+          "version": "0.0.2",
+          "dev": true
+        },
+        "crypto-random-string": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "css-slam": {
+          "version": "2.1.2",
+          "dev": true,
+          "requires": {
+            "command-line-args": "^5.0.2",
+            "command-line-usage": "^5.0.5",
+            "dom5": "^3.0.0",
+            "parse5": "^4.0.0",
+            "shady-css-parser": "^0.1.0"
+          }
+        },
+        "css-what": {
+          "version": "2.1.3",
+          "dev": true
+        },
+        "cssbeautify": {
+          "version": "0.3.1",
+          "dev": true
+        },
+        "currently-unhandled": {
+          "version": "0.4.1",
+          "dev": true,
+          "requires": {
+            "array-find-index": "^1.0.1"
+          }
+        },
+        "dargs": {
+          "version": "6.0.0",
+          "dev": true
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "dev": true,
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
+        },
+        "dateformat": {
+          "version": "3.0.3",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "dev": true
+        },
+        "decode-uri-component": {
+          "version": "0.2.0",
+          "dev": true
+        },
+        "decompress-response": {
+          "version": "3.3.0",
+          "dev": true,
+          "requires": {
+            "mimic-response": "^1.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "dev": true
+        },
+        "deepmerge": {
+          "version": "3.2.0",
+          "dev": true
+        },
+        "define-property": {
+          "version": "2.0.2",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.2",
+            "isobject": "^3.0.1"
+          },
+          "dependencies": {
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "dev": true
+            }
+          }
+        },
+        "del": {
+          "version": "3.0.0",
+          "dev": true,
+          "requires": {
+            "globby": "^6.1.0",
+            "is-path-cwd": "^1.0.0",
+            "is-path-in-cwd": "^1.0.0",
+            "p-map": "^1.1.1",
+            "pify": "^3.0.0",
+            "rimraf": "^2.2.8"
+          },
+          "dependencies": {
+            "globby": {
+              "version": "6.1.0",
+              "dev": true,
+              "requires": {
+                "array-union": "^1.0.1",
+                "glob": "^7.0.3",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              },
+              "dependencies": {
+                "pify": {
+                  "version": "2.3.0",
+                  "dev": true
+                }
+              }
+            },
+            "pify": {
+              "version": "3.0.0",
+              "dev": true
+            }
+          }
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "depd": {
+          "version": "1.1.2",
+          "dev": true
+        },
+        "destroy": {
+          "version": "1.0.4",
+          "dev": true
+        },
+        "detect-conflict": {
+          "version": "1.0.1",
+          "dev": true
+        },
+        "detect-file": {
+          "version": "0.1.0",
+          "dev": true,
+          "requires": {
+            "fs-exists-sync": "^0.1.0"
+          }
+        },
+        "detect-indent": {
+          "version": "4.0.0",
+          "dev": true,
+          "requires": {
+            "repeating": "^2.0.0"
+          }
+        },
+        "detect-node": {
+          "version": "2.0.4",
+          "dev": true
+        },
+        "diagnostics": {
+          "version": "1.1.1",
+          "dev": true,
+          "requires": {
+            "colorspace": "1.1.x",
+            "enabled": "1.0.x",
+            "kuler": "1.0.x"
+          }
+        },
+        "dicer": {
+          "version": "0.2.5",
+          "dev": true,
+          "requires": {
+            "readable-stream": "1.1.x",
+            "streamsearch": "0.1.2"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "1.1.14",
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+              }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "dev": true
+            }
+          }
+        },
+        "diff": {
+          "version": "3.5.0",
+          "dev": true
+        },
+        "dir-glob": {
+          "version": "2.0.0",
+          "dev": true,
+          "requires": {
+            "arrify": "^1.0.1",
+            "path-type": "^3.0.0"
+          },
+          "dependencies": {
+            "path-type": {
+              "version": "3.0.0",
+              "dev": true,
+              "requires": {
+                "pify": "^3.0.0"
+              }
+            },
+            "pify": {
+              "version": "3.0.0",
+              "dev": true
+            }
+          }
+        },
+        "doctrine": {
+          "version": "2.1.0",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "dom-urls": {
+          "version": "1.1.0",
+          "dev": true,
+          "requires": {
+            "urijs": "^1.16.1"
+          }
+        },
+        "dom5": {
+          "version": "3.0.1",
+          "dev": true,
+          "requires": {
+            "@types/parse5": "^2.2.34",
+            "clone": "^2.1.0",
+            "parse5": "^4.0.0"
+          }
+        },
+        "dot-prop": {
+          "version": "4.2.0",
+          "dev": true,
+          "requires": {
+            "is-obj": "^1.0.0"
+          }
+        },
+        "duplexer2": {
+          "version": "0.1.4",
+          "dev": true,
+          "requires": {
+            "readable-stream": "^2.0.2"
+          }
+        },
+        "duplexer3": {
+          "version": "0.1.4",
+          "dev": true
+        },
+        "duplexify": {
+          "version": "3.7.1",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.0",
+            "stream-shift": "^1.0.0"
+          }
+        },
+        "ecc-jsbn": {
+          "version": "0.1.2",
+          "dev": true,
+          "requires": {
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.1.0"
+          }
+        },
+        "editions": {
+          "version": "2.1.3",
+          "dev": true,
+          "requires": {
+            "errlop": "^1.1.1",
+            "semver": "^5.6.0"
+          }
+        },
+        "ee-first": {
+          "version": "1.1.1",
+          "dev": true
+        },
+        "ejs": {
+          "version": "2.6.1",
+          "dev": true
+        },
+        "emitter-component": {
+          "version": "1.1.1",
+          "dev": true
+        },
+        "enabled": {
+          "version": "1.0.2",
+          "dev": true,
+          "requires": {
+            "env-variable": "0.0.x"
+          }
+        },
+        "encodeurl": {
+          "version": "1.0.2",
+          "dev": true
+        },
+        "end-of-stream": {
+          "version": "1.4.1",
+          "dev": true,
+          "requires": {
+            "once": "^1.4.0"
+          }
+        },
+        "ends-with": {
+          "version": "0.2.0",
+          "dev": true
+        },
+        "engine.io": {
+          "version": "3.3.2",
+          "dev": true,
+          "requires": {
+            "accepts": "~1.3.4",
+            "base64id": "1.0.0",
+            "cookie": "0.3.1",
+            "debug": "~3.1.0",
+            "engine.io-parser": "~2.1.0",
+            "ws": "~6.1.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "engine.io-client": {
+          "version": "3.3.2",
+          "dev": true,
+          "requires": {
+            "component-emitter": "1.2.1",
+            "component-inherit": "0.0.3",
+            "debug": "~3.1.0",
+            "engine.io-parser": "~2.1.1",
+            "has-cors": "1.1.0",
+            "indexof": "0.0.1",
+            "parseqs": "0.0.5",
+            "parseuri": "0.0.5",
+            "ws": "~6.1.0",
+            "xmlhttprequest-ssl": "~1.5.4",
+            "yeast": "0.1.2"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "engine.io-parser": {
+          "version": "2.1.3",
+          "dev": true,
+          "requires": {
+            "after": "0.8.2",
+            "arraybuffer.slice": "~0.0.7",
+            "base64-arraybuffer": "0.1.5",
+            "blob": "0.0.5",
+            "has-binary2": "~1.0.2"
+          }
+        },
+        "env-variable": {
+          "version": "0.0.5",
+          "dev": true
+        },
+        "errlop": {
+          "version": "1.1.1",
+          "dev": true,
+          "requires": {
+            "editions": "^2.1.2"
+          }
+        },
+        "error": {
+          "version": "7.0.2",
+          "dev": true,
+          "requires": {
+            "string-template": "~0.2.1",
+            "xtend": "~4.0.0"
+          }
+        },
+        "error-ex": {
+          "version": "1.3.2",
+          "dev": true,
+          "requires": {
+            "is-arrayish": "^0.2.1"
+          }
+        },
+        "es6-promise": {
+          "version": "4.2.6",
+          "dev": true
+        },
+        "es6-promisify": {
+          "version": "6.0.1",
+          "dev": true
+        },
+        "escape-html": {
+          "version": "1.0.3",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "dev": true
+        },
+        "espree": {
+          "version": "3.5.4",
+          "dev": true,
+          "requires": {
+            "acorn": "^5.5.0",
+            "acorn-jsx": "^3.0.0"
+          }
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "dev": true
+        },
+        "etag": {
+          "version": "1.8.1",
+          "dev": true
+        },
+        "eventemitter3": {
+          "version": "3.1.0",
+          "dev": true
+        },
+        "execa": {
+          "version": "0.10.0",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "exit-hook": {
+          "version": "1.1.1",
+          "dev": true
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "dev": true,
+          "requires": {
+            "is-posix-bracket": "^0.1.0"
+          }
+        },
+        "expand-range": {
+          "version": "1.8.2",
+          "dev": true,
+          "requires": {
+            "fill-range": "^2.1.0"
+          }
+        },
+        "expand-tilde": {
+          "version": "1.2.2",
+          "dev": true,
+          "requires": {
+            "os-homedir": "^1.0.1"
+          }
+        },
+        "express": {
+          "version": "4.16.4",
+          "dev": true,
+          "requires": {
+            "accepts": "~1.3.5",
+            "array-flatten": "1.1.1",
+            "body-parser": "1.18.3",
+            "content-disposition": "0.5.2",
+            "content-type": "~1.0.4",
+            "cookie": "0.3.1",
+            "cookie-signature": "1.0.6",
+            "debug": "2.6.9",
+            "depd": "~1.1.2",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
+            "finalhandler": "1.1.1",
+            "fresh": "0.5.2",
+            "merge-descriptors": "1.0.1",
+            "methods": "~1.1.2",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.2",
+            "path-to-regexp": "0.1.7",
+            "proxy-addr": "~2.0.4",
+            "qs": "6.5.2",
+            "range-parser": "~1.2.0",
+            "safe-buffer": "5.1.2",
+            "send": "0.16.2",
+            "serve-static": "1.13.2",
+            "setprototypeof": "1.1.0",
+            "statuses": "~1.4.0",
+            "type-is": "~1.6.16",
+            "utils-merge": "1.0.1",
+            "vary": "~1.1.2"
+          },
+          "dependencies": {
+            "path-to-regexp": {
+              "version": "0.1.7",
+              "dev": true
+            }
+          }
+        },
+        "ext-list": {
+          "version": "2.2.2",
+          "dev": true,
+          "requires": {
+            "mime-db": "^1.28.0"
+          }
+        },
+        "ext-name": {
+          "version": "3.0.0",
+          "dev": true,
+          "requires": {
+            "ends-with": "^0.2.0",
+            "ext-list": "^2.0.0",
+            "meow": "^3.1.0",
+            "sort-keys-length": "^1.0.0"
+          }
+        },
+        "extend": {
+          "version": "3.0.2",
+          "dev": true
+        },
+        "extend-shallow": {
+          "version": "3.0.2",
+          "dev": true,
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "dev": true,
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
+          }
+        },
+        "external-editor": {
+          "version": "1.1.1",
+          "dev": true,
+          "requires": {
+            "extend": "^3.0.0",
+            "spawn-sync": "^1.0.15",
+            "tmp": "^0.0.29"
+          },
+          "dependencies": {
+            "tmp": {
+              "version": "0.0.29",
+              "dev": true,
+              "requires": {
+                "os-tmpdir": "~1.0.1"
+              }
+            }
+          }
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        },
+        "extsprintf": {
+          "version": "1.3.0",
+          "dev": true
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "dev": true
+        },
+        "fast-glob": {
+          "version": "2.2.6",
+          "dev": true,
+          "requires": {
+            "@mrmlnc/readdir-enhanced": "^2.2.1",
+            "@nodelib/fs.stat": "^1.1.2",
+            "glob-parent": "^3.1.0",
+            "is-glob": "^4.0.0",
+            "merge2": "^1.2.3",
+            "micromatch": "^3.1.10"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "4.0.0",
+              "dev": true
+            },
+            "array-unique": {
+              "version": "0.3.2",
+              "dev": true
+            },
+            "braces": {
+              "version": "2.3.2",
+              "dev": true,
+              "requires": {
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "dev": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "expand-brackets": {
+              "version": "2.1.4",
+              "dev": true,
+              "requires": {
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "0.2.5",
+                  "dev": true,
+                  "requires": {
+                    "is-descriptor": "^0.1.0"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "dev": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                },
+                "is-accessor-descriptor": {
+                  "version": "0.1.6",
+                  "dev": true,
+                  "requires": {
+                    "kind-of": "^3.0.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "dev": true,
+                      "requires": {
+                        "is-buffer": "^1.1.5"
+                      }
+                    }
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "0.1.4",
+                  "dev": true,
+                  "requires": {
+                    "kind-of": "^3.0.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "dev": true,
+                      "requires": {
+                        "is-buffer": "^1.1.5"
+                      }
+                    }
+                  }
+                },
+                "is-descriptor": {
+                  "version": "0.1.6",
+                  "dev": true,
+                  "requires": {
+                    "is-accessor-descriptor": "^0.1.6",
+                    "is-data-descriptor": "^0.1.4",
+                    "kind-of": "^5.0.0"
+                  }
+                },
+                "kind-of": {
+                  "version": "5.1.0",
+                  "dev": true
+                }
+              }
+            },
+            "extglob": {
+              "version": "2.0.4",
+              "dev": true,
+              "requires": {
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "1.0.0",
+                  "dev": true,
+                  "requires": {
+                    "is-descriptor": "^1.0.0"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "dev": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "fill-range": {
+              "version": "4.0.0",
+              "dev": true,
+              "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "dev": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "glob-parent": {
+              "version": "3.1.0",
+              "dev": true,
+              "requires": {
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
+              },
+              "dependencies": {
+                "is-glob": {
+                  "version": "3.1.0",
+                  "dev": true,
+                  "requires": {
+                    "is-extglob": "^2.1.0"
+                  }
+                }
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            },
+            "is-extglob": {
+              "version": "2.1.1",
+              "dev": true
+            },
+            "is-glob": {
+              "version": "4.0.0",
+              "dev": true,
+              "requires": {
+                "is-extglob": "^2.1.1"
+              }
+            },
+            "is-number": {
+              "version": "3.0.0",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "dev": true
+            },
+            "micromatch": {
+              "version": "3.1.10",
+              "dev": true,
+              "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
+              }
+            }
+          }
+        },
+        "fast-json-stable-stringify": {
+          "version": "2.0.0",
+          "dev": true
+        },
+        "fast-levenshtein": {
+          "version": "2.0.6",
+          "dev": true
+        },
+        "fast-safe-stringify": {
+          "version": "2.0.6",
+          "dev": true
+        },
+        "fd-slicer": {
+          "version": "1.1.0",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "pend": "~1.2.0"
+          }
+        },
+        "fecha": {
+          "version": "2.3.3",
+          "dev": true
+        },
+        "figures": {
+          "version": "1.7.0",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
+          }
+        },
+        "filename-regex": {
+          "version": "2.0.1",
+          "dev": true
+        },
+        "fill-range": {
+          "version": "2.2.4",
+          "dev": true,
+          "requires": {
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^3.0.0",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "filled-array": {
+          "version": "1.1.0",
+          "dev": true
+        },
+        "finalhandler": {
+          "version": "1.1.1",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.2",
+            "statuses": "~1.4.0",
+            "unpipe": "~1.0.0"
+          }
+        },
+        "find-port": {
+          "version": "1.0.1",
+          "dev": true,
+          "requires": {
+            "async": "~0.2.9"
+          },
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "dev": true
+            }
+          }
+        },
+        "find-replace": {
+          "version": "2.0.1",
+          "dev": true,
+          "requires": {
+            "array-back": "^2.0.0",
+            "test-value": "^3.0.0"
+          }
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "dev": true,
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "findup-sync": {
+          "version": "0.4.3",
+          "dev": true,
+          "requires": {
+            "detect-file": "^0.1.0",
+            "is-glob": "^2.0.1",
+            "micromatch": "^2.3.7",
+            "resolve-dir": "^0.1.0"
+          }
+        },
+        "first-chunk-stream": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "follow-redirects": {
+          "version": "1.7.0",
+          "dev": true,
+          "requires": {
+            "debug": "^3.2.6"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.2.6",
+              "dev": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "ms": {
+              "version": "2.1.1",
+              "dev": true
+            }
+          }
+        },
+        "for-in": {
+          "version": "1.0.2",
+          "dev": true
+        },
+        "for-own": {
+          "version": "0.1.5",
+          "dev": true,
+          "requires": {
+            "for-in": "^1.0.1"
+          }
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "dev": true
+        },
+        "fork-stream": {
+          "version": "0.0.4",
+          "dev": true
+        },
+        "form-data": {
+          "version": "2.3.3",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "formatio": {
+          "version": "1.2.0",
+          "dev": true,
+          "requires": {
+            "samsam": "1.x"
+          }
+        },
+        "forwarded": {
+          "version": "0.1.2",
+          "dev": true
+        },
+        "fragment-cache": {
+          "version": "0.2.1",
+          "dev": true,
+          "requires": {
+            "map-cache": "^0.2.2"
+          }
+        },
+        "freeport": {
+          "version": "1.0.5",
+          "dev": true,
+          "optional": true
+        },
+        "fresh": {
+          "version": "0.5.2",
+          "dev": true
+        },
+        "fs-constants": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "fs-exists-sync": {
+          "version": "0.1.0",
+          "dev": true
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "get-stdin": {
+          "version": "4.0.1",
+          "dev": true
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "dev": true
+        },
+        "get-value": {
+          "version": "2.0.6",
+          "dev": true
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "dev": true,
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
+        },
+        "gh-got": {
+          "version": "6.0.0",
+          "dev": true,
+          "requires": {
+            "got": "^7.0.0",
+            "is-plain-obj": "^1.1.0"
+          },
+          "dependencies": {
+            "got": {
+              "version": "7.1.0",
+              "dev": true,
+              "requires": {
+                "decompress-response": "^3.2.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "is-plain-obj": "^1.1.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "isurl": "^1.0.0-alpha5",
+                "lowercase-keys": "^1.0.0",
+                "p-cancelable": "^0.3.0",
+                "p-timeout": "^1.1.1",
+                "safe-buffer": "^5.0.1",
+                "timed-out": "^4.0.0",
+                "url-parse-lax": "^1.0.0",
+                "url-to-options": "^1.0.1"
+              }
+            }
+          }
+        },
+        "github-username": {
+          "version": "4.1.0",
+          "dev": true,
+          "requires": {
+            "gh-got": "^6.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "glob-base": {
+          "version": "0.3.0",
+          "dev": true,
+          "requires": {
+            "glob-parent": "^2.0.0",
+            "is-glob": "^2.0.0"
+          }
+        },
+        "glob-parent": {
+          "version": "2.0.0",
+          "dev": true,
+          "requires": {
+            "is-glob": "^2.0.0"
+          }
+        },
+        "glob-stream": {
+          "version": "5.3.5",
+          "dev": true,
+          "requires": {
+            "extend": "^3.0.0",
+            "glob": "^5.0.3",
+            "glob-parent": "^3.0.0",
+            "micromatch": "^2.3.7",
+            "ordered-read-streams": "^0.3.0",
+            "through2": "^0.6.0",
+            "to-absolute-glob": "^0.1.1",
+            "unique-stream": "^2.0.2"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "5.0.15",
+              "dev": true,
+              "requires": {
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "2 || 3",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "glob-parent": {
+              "version": "3.1.0",
+              "dev": true,
+              "requires": {
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
+              }
+            },
+            "is-extglob": {
+              "version": "2.1.1",
+              "dev": true
+            },
+            "is-glob": {
+              "version": "3.1.0",
+              "dev": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "1.0.34",
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+              }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "dev": true
+            },
+            "through2": {
+              "version": "0.6.5",
+              "dev": true,
+              "requires": {
+                "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                "xtend": ">=4.0.0 <4.1.0-0"
+              }
+            }
+          }
+        },
+        "glob-to-regexp": {
+          "version": "0.3.0",
+          "dev": true
+        },
+        "global-dirs": {
+          "version": "0.1.1",
+          "dev": true,
+          "requires": {
+            "ini": "^1.3.4"
+          }
+        },
+        "global-modules": {
+          "version": "0.2.3",
+          "dev": true,
+          "requires": {
+            "global-prefix": "^0.1.4",
+            "is-windows": "^0.2.0"
+          },
+          "dependencies": {
+            "is-windows": {
+              "version": "0.2.0",
+              "dev": true
+            }
+          }
+        },
+        "global-prefix": {
+          "version": "0.1.5",
+          "dev": true,
+          "requires": {
+            "homedir-polyfill": "^1.0.0",
+            "ini": "^1.3.4",
+            "is-windows": "^0.2.0",
+            "which": "^1.2.12"
+          },
+          "dependencies": {
+            "is-windows": {
+              "version": "0.2.0",
+              "dev": true
+            }
+          }
+        },
+        "globals": {
+          "version": "11.11.0",
+          "dev": true
+        },
+        "globby": {
+          "version": "8.0.2",
+          "dev": true,
+          "requires": {
+            "array-union": "^1.0.1",
+            "dir-glob": "2.0.0",
+            "fast-glob": "^2.0.2",
+            "glob": "^7.1.2",
+            "ignore": "^3.3.5",
+            "pify": "^3.0.0",
+            "slash": "^1.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "3.0.0",
+              "dev": true
+            }
+          }
+        },
+        "got": {
+          "version": "6.7.1",
+          "dev": true,
+          "requires": {
+            "create-error-class": "^3.0.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "is-redirect": "^1.0.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "lowercase-keys": "^1.0.0",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "unzip-response": "^2.0.1",
+            "url-parse-lax": "^1.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.15",
+          "dev": true
+        },
+        "grouped-queue": {
+          "version": "0.3.3",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.2"
+          }
+        },
+        "gulp-if": {
+          "version": "2.0.2",
+          "dev": true,
+          "requires": {
+            "gulp-match": "^1.0.3",
+            "ternary-stream": "^2.0.1",
+            "through2": "^2.0.1"
+          }
+        },
+        "gulp-match": {
+          "version": "1.0.3",
+          "dev": true,
+          "requires": {
+            "minimatch": "^3.0.3"
+          }
+        },
+        "gulp-sourcemaps": {
+          "version": "1.6.0",
+          "dev": true,
+          "requires": {
+            "convert-source-map": "^1.1.1",
+            "graceful-fs": "^4.1.2",
+            "strip-bom": "^2.0.0",
+            "through2": "^2.0.0",
+            "vinyl": "^1.0.0"
+          }
+        },
+        "gunzip-maybe": {
+          "version": "1.4.1",
+          "dev": true,
+          "requires": {
+            "browserify-zlib": "^0.1.4",
+            "is-deflate": "^1.0.0",
+            "is-gzip": "^1.0.0",
+            "peek-stream": "^1.1.0",
+            "pumpify": "^1.3.3",
+            "through2": "^2.0.3"
+          }
+        },
+        "handle-thing": {
+          "version": "1.2.5",
+          "dev": true
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "dev": true
+        },
+        "har-validator": {
+          "version": "5.1.3",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.5.5",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "has-binary2": {
+          "version": "1.0.3",
+          "dev": true,
+          "requires": {
+            "isarray": "2.0.1"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "2.0.1",
+              "dev": true
+            }
+          }
+        },
+        "has-color": {
+          "version": "0.1.7",
+          "dev": true
+        },
+        "has-cors": {
+          "version": "1.1.0",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "dev": true
+        },
+        "has-symbol-support-x": {
+          "version": "1.4.2",
+          "dev": true
+        },
+        "has-to-string-tag-x": {
+          "version": "1.4.1",
+          "dev": true,
+          "requires": {
+            "has-symbol-support-x": "^1.4.1"
+          }
+        },
+        "has-value": {
+          "version": "1.0.0",
+          "dev": true,
+          "requires": {
+            "get-value": "^2.0.6",
+            "has-values": "^1.0.0",
+            "isobject": "^3.0.0"
+          }
+        },
+        "has-values": {
+          "version": "1.0.0",
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "kind-of": "^4.0.0"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "3.0.0",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "kind-of": {
+              "version": "4.0.0",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "he": {
+          "version": "1.2.0",
+          "dev": true
+        },
+        "homedir-polyfill": {
+          "version": "1.0.3",
+          "dev": true,
+          "requires": {
+            "parse-passwd": "^1.0.0"
+          }
+        },
+        "hosted-git-info": {
+          "version": "2.7.1",
+          "dev": true
+        },
+        "hpack.js": {
+          "version": "2.1.6",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "obuf": "^1.0.0",
+            "readable-stream": "^2.0.1",
+            "wbuf": "^1.1.0"
+          }
+        },
+        "html-minifier": {
+          "version": "3.5.21",
+          "dev": true,
+          "requires": {
+            "camel-case": "3.0.x",
+            "clean-css": "4.2.x",
+            "commander": "2.17.x",
+            "he": "1.2.x",
+            "param-case": "2.1.x",
+            "relateurl": "0.2.x",
+            "uglify-js": "3.4.x"
+          }
+        },
+        "http-deceiver": {
+          "version": "1.2.7",
+          "dev": true
+        },
+        "http-errors": {
+          "version": "1.6.3",
+          "dev": true,
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.1.0",
+            "statuses": ">= 1.4.0 < 2"
+          }
+        },
+        "http-proxy": {
+          "version": "1.17.0",
+          "dev": true,
+          "requires": {
+            "eventemitter3": "^3.0.0",
+            "follow-redirects": "^1.0.0",
+            "requires-port": "^1.0.0"
+          }
+        },
+        "http-proxy-middleware": {
+          "version": "0.17.4",
+          "dev": true,
+          "requires": {
+            "http-proxy": "^1.16.2",
+            "is-glob": "^3.1.0",
+            "lodash": "^4.17.2",
+            "micromatch": "^2.3.11"
+          },
+          "dependencies": {
+            "is-extglob": {
+              "version": "2.1.1",
+              "dev": true
+            },
+            "is-glob": {
+              "version": "3.1.0",
+              "dev": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "dev": true,
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "2.2.1",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "agent-base": "^4.1.0",
+            "debug": "^3.1.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.2.6",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "ms": {
+              "version": "2.1.1",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.23",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "ieee754": {
+          "version": "1.1.12",
+          "dev": true
+        },
+        "ignore": {
+          "version": "3.3.10",
+          "dev": true
+        },
+        "import-lazy": {
+          "version": "2.1.0",
+          "dev": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "dev": true
+        },
+        "indent": {
+          "version": "0.0.2",
+          "dev": true
+        },
+        "indent-string": {
+          "version": "2.1.0",
+          "dev": true,
+          "requires": {
+            "repeating": "^2.0.0"
+          }
+        },
+        "indexof": {
+          "version": "0.0.1",
+          "dev": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "dev": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "1.2.3",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^1.1.0",
+            "chalk": "^1.0.0",
+            "cli-cursor": "^1.0.1",
+            "cli-width": "^2.0.0",
+            "external-editor": "^1.1.0",
+            "figures": "^1.3.5",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.6",
+            "pinkie-promise": "^2.0.0",
+            "run-async": "^2.2.0",
+            "rx": "^4.1.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.0",
+            "through": "^2.3.6"
+          }
+        },
+        "interpret": {
+          "version": "1.2.0",
+          "dev": true
+        },
+        "intersect": {
+          "version": "1.0.1",
+          "dev": true
+        },
+        "invariant": {
+          "version": "2.2.4",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        },
+        "ipaddr.js": {
+          "version": "1.8.0",
+          "dev": true
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "dev": true
+        },
+        "is-binary-path": {
+          "version": "1.0.1",
+          "dev": true,
+          "requires": {
+            "binary-extensions": "^1.0.0"
+          }
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "dev": true
+        },
+        "is-ci": {
+          "version": "1.2.1",
+          "dev": true,
+          "requires": {
+            "ci-info": "^1.5.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "is-deflate": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "5.1.0",
+              "dev": true
+            }
+          }
+        },
+        "is-dotfile": {
+          "version": "1.0.3",
+          "dev": true
+        },
+        "is-equal-shallow": {
+          "version": "0.1.3",
+          "dev": true,
+          "requires": {
+            "is-primitive": "^2.0.0"
+          }
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "dev": true
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "is-finite": {
+          "version": "1.0.2",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        },
+        "is-gzip": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "is-installed-globally": {
+          "version": "0.1.0",
+          "dev": true,
+          "requires": {
+            "global-dirs": "^0.1.0",
+            "is-path-inside": "^1.0.0"
+          }
+        },
+        "is-npm": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "is-number": {
+          "version": "2.1.0",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "is-obj": {
+          "version": "1.0.1",
+          "dev": true
+        },
+        "is-object": {
+          "version": "1.0.1",
+          "dev": true
+        },
+        "is-path-cwd": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "is-path-in-cwd": {
+          "version": "1.0.1",
+          "dev": true,
+          "requires": {
+            "is-path-inside": "^1.0.0"
+          }
+        },
+        "is-path-inside": {
+          "version": "1.0.1",
+          "dev": true,
+          "requires": {
+            "path-is-inside": "^1.0.1"
+          }
+        },
+        "is-plain-obj": {
+          "version": "1.1.0",
+          "dev": true
+        },
+        "is-plain-object": {
+          "version": "2.0.4",
+          "dev": true,
+          "requires": {
+            "isobject": "^3.0.1"
+          }
+        },
+        "is-posix-bracket": {
+          "version": "0.1.1",
+          "dev": true
+        },
+        "is-potential-custom-element-name": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "is-primitive": {
+          "version": "2.0.0",
+          "dev": true
+        },
+        "is-promise": {
+          "version": "2.1.0",
+          "dev": true
+        },
+        "is-redirect": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "is-retry-allowed": {
+          "version": "1.1.0",
+          "dev": true
+        },
+        "is-scoped": {
+          "version": "1.0.0",
+          "dev": true,
+          "requires": {
+            "scoped-regex": "^1.0.0"
+          }
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "dev": true
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "is-utf8": {
+          "version": "0.2.1",
+          "dev": true
+        },
+        "is-valid-glob": {
+          "version": "0.3.0",
+          "dev": true
+        },
+        "is-windows": {
+          "version": "1.0.2",
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "isbinaryfile": {
+          "version": "3.0.3",
+          "dev": true,
+          "requires": {
+            "buffer-alloc": "^1.2.0"
+          }
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "dev": true
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "dev": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "dev": true
+        },
+        "istextorbinary": {
+          "version": "2.5.1",
+          "dev": true,
+          "requires": {
+            "binaryextensions": "^2.1.2",
+            "editions": "^2.1.3",
+            "textextensions": "^2.4.0"
+          }
+        },
+        "isurl": {
+          "version": "1.0.0",
+          "dev": true,
+          "requires": {
+            "has-to-string-tag-x": "^1.2.0",
+            "is-object": "^1.0.1"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "dev": true
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "dev": true
+        },
+        "jsesc": {
+          "version": "2.5.2",
+          "dev": true
+        },
+        "json-parse-better-errors": {
+          "version": "1.0.2",
+          "dev": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "dev": true
+        },
+        "json-stable-stringify-without-jsonify": {
+          "version": "1.0.1",
+          "dev": true
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "dev": true
+        },
+        "json5": {
+          "version": "2.1.0",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "jsonschema": {
+          "version": "1.2.4",
+          "dev": true
+        },
+        "jsprim": {
+          "version": "1.4.1",
+          "dev": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.2.3",
+            "verror": "1.10.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        },
+        "kuler": {
+          "version": "1.0.1",
+          "dev": true,
+          "requires": {
+            "colornames": "^1.1.1"
+          }
+        },
+        "latest-version": {
+          "version": "3.1.0",
+          "dev": true,
+          "requires": {
+            "package-json": "^4.0.0"
+          }
+        },
+        "launchpad": {
+          "version": "0.7.1",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "async": "^2.0.1",
+            "browserstack": "^1.2.0",
+            "debug": "^2.2.0",
+            "plist": "^2.0.1",
+            "q": "^1.4.1",
+            "underscore": "^1.8.3"
+          },
+          "dependencies": {
+            "underscore": {
+              "version": "1.9.1",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "lazy-req": {
+          "version": "1.1.0",
+          "dev": true
+        },
+        "lazystream": {
+          "version": "1.0.0",
+          "dev": true,
+          "requires": {
+            "readable-stream": "^2.0.5"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          },
+          "dependencies": {
+            "path-exists": {
+              "version": "3.0.0",
+              "dev": true
+            }
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "dev": true
+        },
+        "lodash._reinterpolate": {
+          "version": "3.0.0",
+          "dev": true
+        },
+        "lodash.camelcase": {
+          "version": "4.3.0",
+          "dev": true
+        },
+        "lodash.defaults": {
+          "version": "4.2.0",
+          "dev": true
+        },
+        "lodash.get": {
+          "version": "4.4.2",
+          "dev": true
+        },
+        "lodash.isequal": {
+          "version": "4.5.0",
+          "dev": true
+        },
+        "lodash.isplainobject": {
+          "version": "4.0.6",
+          "dev": true
+        },
+        "lodash.padend": {
+          "version": "4.6.1",
+          "dev": true
+        },
+        "lodash.set": {
+          "version": "4.3.2",
+          "dev": true
+        },
+        "lodash.some": {
+          "version": "4.6.0",
+          "dev": true
+        },
+        "lodash.sortby": {
+          "version": "4.7.0",
+          "dev": true
+        },
+        "lodash.template": {
+          "version": "4.4.0",
+          "dev": true,
+          "requires": {
+            "lodash._reinterpolate": "~3.0.0",
+            "lodash.templatesettings": "^4.0.0"
+          }
+        },
+        "lodash.templatesettings": {
+          "version": "4.1.0",
+          "dev": true,
+          "requires": {
+            "lodash._reinterpolate": "~3.0.0"
+          }
+        },
+        "lodash.uniq": {
+          "version": "4.5.0",
+          "dev": true
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "dev": true,
+          "requires": {
+            "chalk": "^1.0.0"
+          }
+        },
+        "logform": {
+          "version": "1.10.0",
+          "dev": true,
+          "requires": {
+            "colors": "^1.2.1",
+            "fast-safe-stringify": "^2.0.4",
+            "fecha": "^2.3.3",
+            "ms": "^2.1.1",
+            "triple-beam": "^1.2.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.1.1",
+              "dev": true
+            }
+          }
+        },
+        "lolex": {
+          "version": "1.6.0",
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "loud-rejection": {
+          "version": "1.6.0",
+          "dev": true,
+          "requires": {
+            "currently-unhandled": "^0.4.1",
+            "signal-exit": "^3.0.0"
+          }
+        },
+        "lower-case": {
+          "version": "1.1.4",
+          "dev": true
+        },
+        "lowercase-keys": {
+          "version": "1.0.1",
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "4.1.5",
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "macos-release": {
+          "version": "2.0.0",
+          "dev": true
+        },
+        "magic-string": {
+          "version": "0.22.5",
+          "dev": true,
+          "requires": {
+            "vlq": "^0.2.2"
+          }
+        },
+        "make-dir": {
+          "version": "1.3.0",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "3.0.0",
+              "dev": true
+            }
+          }
+        },
+        "map-cache": {
+          "version": "0.2.2",
+          "dev": true
+        },
+        "map-obj": {
+          "version": "1.0.1",
+          "dev": true
+        },
+        "map-visit": {
+          "version": "1.0.0",
+          "dev": true,
+          "requires": {
+            "object-visit": "^1.0.0"
+          }
+        },
+        "matcher": {
+          "version": "1.1.1",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.4"
+          }
+        },
+        "math-random": {
+          "version": "1.0.4",
+          "dev": true
+        },
+        "md5": {
+          "version": "2.2.1",
+          "dev": true,
+          "requires": {
+            "charenc": "~0.0.1",
+            "crypt": "~0.0.1",
+            "is-buffer": "~1.1.1"
+          }
+        },
+        "media-typer": {
+          "version": "0.3.0",
+          "dev": true
+        },
+        "mem-fs": {
+          "version": "1.1.3",
+          "dev": true,
+          "requires": {
+            "through2": "^2.0.0",
+            "vinyl": "^1.1.0",
+            "vinyl-file": "^2.0.0"
+          }
+        },
+        "mem-fs-editor": {
+          "version": "5.1.0",
+          "dev": true,
+          "requires": {
+            "commondir": "^1.0.1",
+            "deep-extend": "^0.6.0",
+            "ejs": "^2.5.9",
+            "glob": "^7.0.3",
+            "globby": "^8.0.1",
+            "isbinaryfile": "^3.0.2",
+            "mkdirp": "^0.5.0",
+            "multimatch": "^2.0.0",
+            "rimraf": "^2.2.8",
+            "through2": "^2.0.0",
+            "vinyl": "^2.0.1"
+          },
+          "dependencies": {
+            "clone-stats": {
+              "version": "1.0.0",
+              "dev": true
+            },
+            "deep-extend": {
+              "version": "0.6.0",
+              "dev": true
+            },
+            "replace-ext": {
+              "version": "1.0.0",
+              "dev": true
+            },
+            "vinyl": {
+              "version": "2.2.0",
+              "dev": true,
+              "requires": {
+                "clone": "^2.1.1",
+                "clone-buffer": "^1.0.0",
+                "clone-stats": "^1.0.0",
+                "cloneable-readable": "^1.0.0",
+                "remove-trailing-separator": "^1.0.1",
+                "replace-ext": "^1.0.0"
+              }
+            }
+          }
+        },
+        "meow": {
+          "version": "3.7.0",
+          "dev": true,
+          "requires": {
+            "camelcase-keys": "^2.0.0",
+            "decamelize": "^1.1.2",
+            "loud-rejection": "^1.0.0",
+            "map-obj": "^1.0.1",
+            "minimist": "^1.1.3",
+            "normalize-package-data": "^2.3.4",
+            "object-assign": "^4.0.1",
+            "read-pkg-up": "^1.0.1",
+            "redent": "^1.0.0",
+            "trim-newlines": "^1.0.0"
+          }
+        },
+        "merge-descriptors": {
+          "version": "1.0.1",
+          "dev": true
+        },
+        "merge-stream": {
+          "version": "1.0.1",
+          "dev": true,
+          "requires": {
+            "readable-stream": "^2.0.1"
+          }
+        },
+        "merge2": {
+          "version": "1.2.3",
+          "dev": true
+        },
+        "methods": {
+          "version": "1.1.2",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
+          }
+        },
+        "mime": {
+          "version": "2.4.0",
+          "dev": true
+        },
+        "mime-db": {
+          "version": "1.38.0",
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.22",
+          "dev": true,
+          "requires": {
+            "mime-db": "~1.38.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "dev": true
+        },
+        "mimic-response": {
+          "version": "1.0.1",
+          "dev": true
+        },
+        "minimalistic-assert": {
+          "version": "1.0.1",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimatch-all": {
+          "version": "1.1.0",
+          "dev": true,
+          "requires": {
+            "minimatch": "^3.0.2"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "dev": true
+        },
+        "mixin-deep": {
+          "version": "1.3.1",
+          "dev": true,
+          "requires": {
+            "for-in": "^1.0.2",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "dev": true,
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "dev": true
+            }
+          }
+        },
+        "mout": {
+          "version": "1.1.0",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "dev": true
+        },
+        "multer": {
+          "version": "1.4.1",
+          "dev": true,
+          "requires": {
+            "append-field": "^1.0.0",
+            "busboy": "^0.2.11",
+            "concat-stream": "^1.5.2",
+            "mkdirp": "^0.5.1",
+            "object-assign": "^4.1.1",
+            "on-finished": "^2.3.0",
+            "type-is": "^1.6.4",
+            "xtend": "^4.0.0"
+          }
+        },
+        "multimatch": {
+          "version": "2.1.0",
+          "dev": true,
+          "requires": {
+            "array-differ": "^1.0.0",
+            "array-union": "^1.0.1",
+            "arrify": "^1.0.0",
+            "minimatch": "^3.0.0"
+          }
+        },
+        "multipipe": {
+          "version": "1.0.2",
+          "dev": true,
+          "requires": {
+            "duplexer2": "^0.1.2",
+            "object-assign": "^4.1.0"
+          }
+        },
+        "mute-stream": {
+          "version": "0.0.6",
+          "dev": true
+        },
+        "mz": {
+          "version": "2.7.0",
+          "dev": true,
+          "requires": {
+            "any-promise": "^1.0.0",
+            "object-assign": "^4.0.1",
+            "thenify-all": "^1.0.0"
+          }
+        },
+        "nanomatch": {
+          "version": "1.2.13",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "fragment-cache": "^0.2.1",
+            "is-windows": "^1.0.2",
+            "kind-of": "^6.0.2",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "4.0.0",
+              "dev": true
+            },
+            "array-unique": {
+              "version": "0.3.2",
+              "dev": true
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "dev": true
+            }
+          }
+        },
+        "native-promise-only": {
+          "version": "0.8.1",
+          "dev": true
+        },
+        "negotiator": {
+          "version": "0.6.1",
+          "dev": true
+        },
+        "nice-try": {
+          "version": "1.0.5",
+          "dev": true
+        },
+        "no-case": {
+          "version": "2.3.2",
+          "dev": true,
+          "requires": {
+            "lower-case": "^1.1.1"
+          }
+        },
+        "node-fetch": {
+          "version": "2.3.0",
+          "dev": true
+        },
+        "node-status-codes": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "nomnom": {
+          "version": "1.8.1",
+          "dev": true,
+          "requires": {
+            "chalk": "~0.4.0",
+            "underscore": "~1.6.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "1.0.0",
+              "dev": true
+            },
+            "chalk": {
+              "version": "0.4.0",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "~1.0.0",
+                "has-color": "~0.1.0",
+                "strip-ansi": "~0.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "0.1.1",
+              "dev": true
+            }
+          }
+        },
+        "normalize-package-data": {
+          "version": "2.5.0",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "dev": true,
+          "requires": {
+            "path-key": "^2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.9.0",
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "dev": true
+        },
+        "object-component": {
+          "version": "0.0.3",
+          "dev": true
+        },
+        "object-copy": {
+          "version": "0.1.0",
+          "dev": true,
+          "requires": {
+            "copy-descriptor": "^0.1.0",
+            "define-property": "^0.2.5",
+            "kind-of": "^3.0.3"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            }
+          }
+        },
+        "object-visit": {
+          "version": "1.0.1",
+          "dev": true,
+          "requires": {
+            "isobject": "^3.0.0"
+          }
+        },
+        "object.omit": {
+          "version": "2.0.1",
+          "dev": true,
+          "requires": {
+            "for-own": "^0.1.4",
+            "is-extendable": "^0.1.1"
+          }
+        },
+        "object.pick": {
+          "version": "1.3.0",
+          "dev": true,
+          "requires": {
+            "isobject": "^3.0.1"
+          }
+        },
+        "obuf": {
+          "version": "1.1.2",
+          "dev": true
+        },
+        "octokit-pagination-methods": {
+          "version": "1.1.0",
+          "dev": true
+        },
+        "on-finished": {
+          "version": "2.3.0",
+          "dev": true,
+          "requires": {
+            "ee-first": "1.1.1"
+          }
+        },
+        "on-headers": {
+          "version": "1.0.2",
+          "dev": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "dev": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "one-time": {
+          "version": "0.0.4",
+          "dev": true
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "dev": true
+        },
+        "opn": {
+          "version": "3.0.3",
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.0.1"
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "dev": true,
+          "requires": {
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.10",
+              "dev": true
+            }
+          }
+        },
+        "ordered-read-streams": {
+          "version": "0.3.0",
+          "dev": true,
+          "requires": {
+            "is-stream": "^1.0.1",
+            "readable-stream": "^2.0.1"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "dev": true
+        },
+        "os-name": {
+          "version": "3.0.0",
+          "dev": true,
+          "requires": {
+            "macos-release": "^2.0.0",
+            "windows-release": "^3.1.0"
+          }
+        },
+        "os-shim": {
+          "version": "0.1.3",
+          "dev": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "dev": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "dev": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "p-cancelable": {
+          "version": "0.3.0",
+          "dev": true
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "2.1.0",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-map": {
+          "version": "1.2.0",
+          "dev": true
+        },
+        "p-timeout": {
+          "version": "1.2.1",
+          "dev": true,
+          "requires": {
+            "p-finally": "^1.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.0.0",
+          "dev": true
+        },
+        "package-json": {
+          "version": "4.0.1",
+          "dev": true,
+          "requires": {
+            "got": "^6.7.1",
+            "registry-auth-token": "^3.0.1",
+            "registry-url": "^3.0.3",
+            "semver": "^5.1.0"
+          }
+        },
+        "pako": {
+          "version": "0.2.9",
+          "dev": true
+        },
+        "param-case": {
+          "version": "2.1.1",
+          "dev": true,
+          "requires": {
+            "no-case": "^2.2.0"
+          }
+        },
+        "parse-glob": {
+          "version": "3.0.4",
+          "dev": true,
+          "requires": {
+            "glob-base": "^0.3.0",
+            "is-dotfile": "^1.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "parse-passwd": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "parse5": {
+          "version": "4.0.0",
+          "dev": true
+        },
+        "parseqs": {
+          "version": "0.0.5",
+          "dev": true,
+          "requires": {
+            "better-assert": "~1.0.0"
+          }
+        },
+        "parseuri": {
+          "version": "0.0.5",
+          "dev": true,
+          "requires": {
+            "better-assert": "~1.0.0"
+          }
+        },
+        "parseurl": {
+          "version": "1.3.2",
+          "dev": true
+        },
+        "pascalcase": {
+          "version": "0.1.1",
+          "dev": true
+        },
+        "path-dirname": {
+          "version": "1.0.2",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "dev": true
+        },
+        "path-is-inside": {
+          "version": "1.0.2",
+          "dev": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "dev": true
+        },
+        "path-parse": {
+          "version": "1.0.6",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "dev": true
+            }
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "peek-stream": {
+          "version": "1.1.3",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "duplexify": "^3.5.0",
+            "through2": "^2.0.3"
+          }
+        },
+        "pem": {
+          "version": "1.14.2",
+          "dev": true,
+          "requires": {
+            "es6-promisify": "^6.0.0",
+            "md5": "^2.2.1",
+            "os-tmpdir": "^1.0.1",
+            "which": "^1.3.1"
+          }
+        },
+        "pend": {
+          "version": "1.2.0",
+          "dev": true,
+          "optional": true
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "dev": true
+        },
+        "pify": {
+          "version": "2.3.0",
+          "dev": true
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "dev": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "dev": true,
+          "requires": {
+            "pinkie": "^2.0.0"
+          }
+        },
+        "plist": {
+          "version": "2.1.0",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "base64-js": "1.2.0",
+            "xmlbuilder": "8.2.2",
+            "xmldom": "0.1.x"
+          }
+        },
+        "plylog": {
+          "version": "1.1.0",
+          "dev": true,
+          "requires": {
+            "logform": "^1.9.1",
+            "winston": "^3.0.0",
+            "winston-transport": "^4.2.0"
+          }
+        },
+        "polymer-analyzer": {
+          "version": "3.2.2",
+          "dev": true,
+          "requires": {
+            "@babel/generator": "^7.0.0-beta.42",
+            "@babel/traverse": "^7.0.0-beta.42",
+            "@babel/types": "^7.0.0-beta.42",
+            "@types/babel-generator": "^6.25.1",
+            "@types/babel-traverse": "^6.25.2",
+            "@types/babel-types": "^6.25.1",
+            "@types/babylon": "^6.16.2",
+            "@types/chai-subset": "^1.3.0",
+            "@types/chalk": "^0.4.30",
+            "@types/clone": "^0.1.30",
+            "@types/cssbeautify": "^0.3.1",
+            "@types/doctrine": "^0.0.1",
+            "@types/is-windows": "^0.2.0",
+            "@types/minimatch": "^3.0.1",
+            "@types/parse5": "^2.2.34",
+            "@types/path-is-inside": "^1.0.0",
+            "@types/resolve": "0.0.6",
+            "@types/whatwg-url": "^6.4.0",
+            "babylon": "^7.0.0-beta.42",
+            "cancel-token": "^0.1.1",
+            "chalk": "^1.1.3",
+            "clone": "^2.0.0",
+            "cssbeautify": "^0.3.1",
+            "doctrine": "^2.0.2",
+            "dom5": "^3.0.0",
+            "indent": "0.0.2",
+            "is-windows": "^1.0.2",
+            "jsonschema": "^1.1.0",
+            "minimatch": "^3.0.4",
+            "parse5": "^4.0.0",
+            "path-is-inside": "^1.0.2",
+            "resolve": "^1.5.0",
+            "shady-css-parser": "^0.1.0",
+            "stable": "^0.1.6",
+            "strip-indent": "^2.0.0",
+            "vscode-uri": "^1.0.1",
+            "whatwg-url": "^6.4.0"
+          },
+          "dependencies": {
+            "@types/resolve": {
+              "version": "0.0.6",
+              "dev": true,
+              "requires": {
+                "@types/node": "*"
+              }
+            },
+            "strip-indent": {
+              "version": "2.0.0",
+              "dev": true
+            }
+          }
+        },
+        "polymer-build": {
+          "version": "3.1.2",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.0.0",
+            "@babel/plugin-external-helpers": "^7.0.0",
+            "@babel/plugin-proposal-async-generator-functions": "^7.0.0",
+            "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+            "@babel/plugin-syntax-async-generators": "^7.0.0",
+            "@babel/plugin-syntax-dynamic-import": "^7.0.0",
+            "@babel/plugin-syntax-import-meta": "^7.0.0",
+            "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+            "@babel/plugin-transform-arrow-functions": "^7.0.0",
+            "@babel/plugin-transform-async-to-generator": "^7.0.0",
+            "@babel/plugin-transform-block-scoped-functions": "^7.0.0",
+            "@babel/plugin-transform-block-scoping": "^7.0.0",
+            "@babel/plugin-transform-classes": "^7.0.0",
+            "@babel/plugin-transform-computed-properties": "^7.0.0",
+            "@babel/plugin-transform-destructuring": "^7.0.0",
+            "@babel/plugin-transform-duplicate-keys": "^7.0.0",
+            "@babel/plugin-transform-exponentiation-operator": "^7.0.0",
+            "@babel/plugin-transform-for-of": "^7.0.0",
+            "@babel/plugin-transform-function-name": "^7.0.0",
+            "@babel/plugin-transform-instanceof": "^7.0.0",
+            "@babel/plugin-transform-literals": "^7.0.0",
+            "@babel/plugin-transform-modules-amd": "^7.0.0",
+            "@babel/plugin-transform-object-super": "^7.0.0",
+            "@babel/plugin-transform-parameters": "^7.0.0",
+            "@babel/plugin-transform-regenerator": "^7.0.0",
+            "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+            "@babel/plugin-transform-spread": "^7.0.0",
+            "@babel/plugin-transform-sticky-regex": "^7.0.0",
+            "@babel/plugin-transform-template-literals": "^7.0.0",
+            "@babel/plugin-transform-typeof-symbol": "^7.0.0",
+            "@babel/plugin-transform-unicode-regex": "^7.0.0",
+            "@babel/traverse": "^7.0.0",
+            "@polymer/esm-amd-loader": "^1.0.0",
+            "@types/babel-types": "^6.25.1",
+            "@types/babylon": "^6.16.2",
+            "@types/gulp-if": "0.0.33",
+            "@types/html-minifier": "^3.5.1",
+            "@types/is-windows": "^0.2.0",
+            "@types/mz": "0.0.31",
+            "@types/parse5": "^2.2.34",
+            "@types/resolve": "0.0.7",
+            "@types/uuid": "^3.4.3",
+            "@types/vinyl": "^2.0.0",
+            "@types/vinyl-fs": "^2.4.8",
+            "babel-plugin-minify-guarded-expressions": "=0.4.1",
+            "babel-preset-minify": "=0.4.0-alpha.caaefb4c",
+            "babylon": "^7.0.0-beta.42",
+            "css-slam": "^2.1.2",
+            "dom5": "^3.0.0",
+            "gulp-if": "^2.0.2",
+            "html-minifier": "^3.5.10",
+            "matcher": "^1.1.0",
+            "multipipe": "^1.0.2",
+            "mz": "^2.6.0",
+            "parse5": "^4.0.0",
+            "plylog": "^1.0.0",
+            "polymer-analyzer": "^3.1.3",
+            "polymer-bundler": "^4.0.9",
+            "polymer-project-config": "^4.0.3",
+            "regenerator-runtime": "^0.11.1",
+            "stream": "0.0.2",
+            "sw-precache": "^5.1.1",
+            "uuid": "^3.2.1",
+            "vinyl": "^1.2.0",
+            "vinyl-fs": "^2.4.4"
+          },
+          "dependencies": {
+            "@types/resolve": {
+              "version": "0.0.7",
+              "dev": true,
+              "requires": {
+                "@types/node": "*"
+              }
+            },
+            "@types/vinyl-fs": {
+              "version": "2.4.11",
+              "dev": true,
+              "requires": {
+                "@types/glob-stream": "*",
+                "@types/node": "*",
+                "@types/vinyl": "*"
+              }
+            }
+          }
+        },
+        "polymer-bundler": {
+          "version": "4.0.9",
+          "dev": true,
+          "requires": {
+            "@types/babel-generator": "^6.25.1",
+            "@types/babel-traverse": "^6.25.3",
+            "babel-generator": "^6.26.1",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "clone": "^2.1.0",
+            "command-line-args": "^5.0.2",
+            "command-line-usage": "^5.0.5",
+            "dom5": "^3.0.0",
+            "espree": "^3.5.2",
+            "magic-string": "^0.22.4",
+            "mkdirp": "^0.5.1",
+            "parse5": "^4.0.0",
+            "polymer-analyzer": "^3.2.2",
+            "rollup": "^1.3.0",
+            "source-map": "^0.5.6",
+            "vscode-uri": "^1.0.1"
+          }
+        },
+        "polymer-linter": {
+          "version": "3.0.1",
+          "dev": true,
+          "requires": {
+            "@types/fast-levenshtein": "0.0.1",
+            "@types/parse5": "^2.2.34",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "cancel-token": "^0.1.1",
+            "css-what": "^2.1.0",
+            "dom5": "^3.0.0",
+            "fast-levenshtein": "^2.0.6",
+            "parse5": "^4.0.0",
+            "polymer-analyzer": "^3.0.0",
+            "shady-css-parser": "^0.1.0",
+            "stable": "^0.1.6",
+            "strip-indent": "^2.0.0",
+            "validate-element-name": "^2.1.1"
+          },
+          "dependencies": {
+            "strip-indent": {
+              "version": "2.0.0",
+              "dev": true
+            }
+          }
+        },
+        "polymer-project-config": {
+          "version": "4.0.3",
+          "dev": true,
+          "requires": {
+            "@types/parse5": "^2.2.34",
+            "browser-capabilities": "^1.0.0",
+            "jsonschema": "^1.1.1",
+            "minimatch-all": "^1.1.0",
+            "plylog": "^1.0.0",
+            "winston": "^3.0.0"
+          }
+        },
+        "polyserve": {
+          "version": "0.27.15",
+          "dev": true,
+          "requires": {
+            "@types/compression": "^0.0.33",
+            "@types/content-type": "^1.1.0",
+            "@types/escape-html": "0.0.20",
+            "@types/express": "^4.0.36",
+            "@types/mime": "^2.0.0",
+            "@types/mz": "0.0.29",
+            "@types/opn": "^3.0.28",
+            "@types/parse5": "^2.2.34",
+            "@types/pem": "^1.8.1",
+            "@types/resolve": "0.0.6",
+            "@types/serve-static": "^1.7.31",
+            "@types/spdy": "^3.4.1",
+            "bower-config": "^1.4.1",
+            "browser-capabilities": "^1.0.0",
+            "command-line-args": "^5.0.2",
+            "command-line-usage": "^5.0.5",
+            "compression": "^1.6.2",
+            "content-type": "^1.0.2",
+            "cors": "^2.8.4",
+            "escape-html": "^1.0.3",
+            "express": "^4.8.5",
+            "find-port": "^1.0.1",
+            "http-proxy-middleware": "^0.17.2",
+            "lru-cache": "^4.0.2",
+            "mime": "^2.3.1",
+            "mz": "^2.4.0",
+            "opn": "^3.0.2",
+            "pem": "^1.8.3",
+            "polymer-build": "^3.1.0",
+            "polymer-project-config": "^4.0.0",
+            "requirejs": "^2.3.4",
+            "resolve": "^1.5.0",
+            "send": "^0.16.2",
+            "spdy": "^3.3.3"
+          },
+          "dependencies": {
+            "@types/mz": {
+              "version": "0.0.29",
+              "dev": true,
+              "requires": {
+                "@types/bluebird": "*",
+                "@types/node": "*"
+              }
+            },
+            "@types/resolve": {
+              "version": "0.0.6",
+              "dev": true,
+              "requires": {
+                "@types/node": "*"
+              }
+            }
+          }
+        },
+        "posix-character-classes": {
+          "version": "0.1.1",
+          "dev": true
+        },
+        "prepend-http": {
+          "version": "1.0.4",
+          "dev": true
+        },
+        "preserve": {
+          "version": "0.2.0",
+          "dev": true
+        },
+        "pretty-bytes": {
+          "version": "4.0.2",
+          "dev": true
+        },
+        "private": {
+          "version": "0.1.8",
+          "dev": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "dev": true
+        },
+        "progress": {
+          "version": "2.0.3",
+          "dev": true,
+          "optional": true
+        },
+        "proxy-addr": {
+          "version": "2.0.4",
+          "dev": true,
+          "requires": {
+            "forwarded": "~0.1.2",
+            "ipaddr.js": "1.8.0"
+          }
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "dev": true
+        },
+        "psl": {
+          "version": "1.1.31",
+          "dev": true
+        },
+        "pump": {
+          "version": "2.0.1",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
+        "pumpify": {
+          "version": "1.5.1",
+          "dev": true,
+          "requires": {
+            "duplexify": "^3.6.0",
+            "inherits": "^2.0.3",
+            "pump": "^2.0.0"
+          }
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "dev": true
+        },
+        "q": {
+          "version": "1.5.1",
+          "dev": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.5.2",
+          "dev": true
+        },
+        "randomatic": {
+          "version": "3.1.1",
+          "dev": true,
+          "requires": {
+            "is-number": "^4.0.0",
+            "kind-of": "^6.0.0",
+            "math-random": "^1.0.1"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "4.0.0",
+              "dev": true
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "dev": true
+            }
+          }
+        },
+        "range-parser": {
+          "version": "1.2.0",
+          "dev": true
+        },
+        "raw-body": {
+          "version": "2.3.3",
+          "dev": true,
+          "requires": {
+            "bytes": "3.0.0",
+            "http-errors": "1.6.3",
+            "iconv-lite": "0.4.23",
+            "unpipe": "1.0.0"
+          }
+        },
+        "rc": {
+          "version": "1.2.8",
+          "dev": true,
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          },
+          "dependencies": {
+            "deep-extend": {
+              "version": "0.6.0",
+              "dev": true
+            }
+          }
+        },
+        "read-all-stream": {
+          "version": "3.1.0",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0",
+            "readable-stream": "^2.0.0"
+          }
+        },
+        "read-chunk": {
+          "version": "3.0.0",
+          "dev": true,
+          "requires": {
+            "pify": "^4.0.0",
+            "with-open-file": "^0.1.3"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "4.0.1",
+              "dev": true
+            }
+          }
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "dev": true,
+          "requires": {
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "readdirp": {
+          "version": "2.2.1",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "micromatch": "^3.1.10",
+            "readable-stream": "^2.0.2"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "4.0.0",
+              "dev": true
+            },
+            "array-unique": {
+              "version": "0.3.2",
+              "dev": true
+            },
+            "braces": {
+              "version": "2.3.2",
+              "dev": true,
+              "requires": {
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "dev": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "expand-brackets": {
+              "version": "2.1.4",
+              "dev": true,
+              "requires": {
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "0.2.5",
+                  "dev": true,
+                  "requires": {
+                    "is-descriptor": "^0.1.0"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "dev": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                },
+                "is-accessor-descriptor": {
+                  "version": "0.1.6",
+                  "dev": true,
+                  "requires": {
+                    "kind-of": "^3.0.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "dev": true,
+                      "requires": {
+                        "is-buffer": "^1.1.5"
+                      }
+                    }
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "0.1.4",
+                  "dev": true,
+                  "requires": {
+                    "kind-of": "^3.0.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "dev": true,
+                      "requires": {
+                        "is-buffer": "^1.1.5"
+                      }
+                    }
+                  }
+                },
+                "is-descriptor": {
+                  "version": "0.1.6",
+                  "dev": true,
+                  "requires": {
+                    "is-accessor-descriptor": "^0.1.6",
+                    "is-data-descriptor": "^0.1.4",
+                    "kind-of": "^5.0.0"
+                  }
+                },
+                "kind-of": {
+                  "version": "5.1.0",
+                  "dev": true
+                }
+              }
+            },
+            "extglob": {
+              "version": "2.0.4",
+              "dev": true,
+              "requires": {
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "1.0.0",
+                  "dev": true,
+                  "requires": {
+                    "is-descriptor": "^1.0.0"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "dev": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "fill-range": {
+              "version": "4.0.0",
+              "dev": true,
+              "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "dev": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            },
+            "is-number": {
+              "version": "3.0.0",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "dev": true
+            },
+            "micromatch": {
+              "version": "3.1.10",
+              "dev": true,
+              "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
+              }
+            }
+          }
+        },
+        "rechoir": {
+          "version": "0.6.2",
+          "dev": true,
+          "requires": {
+            "resolve": "^1.1.6"
+          }
+        },
+        "redent": {
+          "version": "1.0.0",
+          "dev": true,
+          "requires": {
+            "indent-string": "^2.1.0",
+            "strip-indent": "^1.0.1"
+          }
+        },
+        "reduce-flatten": {
+          "version": "1.0.1",
+          "dev": true
+        },
+        "regenerate": {
+          "version": "1.4.0",
+          "dev": true
+        },
+        "regenerate-unicode-properties": {
+          "version": "7.0.0",
+          "dev": true,
+          "requires": {
+            "regenerate": "^1.4.0"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "dev": true
+        },
+        "regenerator-transform": {
+          "version": "0.13.4",
+          "dev": true,
+          "requires": {
+            "private": "^0.1.6"
+          }
+        },
+        "regex-cache": {
+          "version": "0.4.4",
+          "dev": true,
+          "requires": {
+            "is-equal-shallow": "^0.1.3"
+          }
+        },
+        "regex-not": {
+          "version": "1.0.2",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^3.0.2",
+            "safe-regex": "^1.1.0"
+          }
+        },
+        "regexpu-core": {
+          "version": "4.4.0",
+          "dev": true,
+          "requires": {
+            "regenerate": "^1.4.0",
+            "regenerate-unicode-properties": "^7.0.0",
+            "regjsgen": "^0.5.0",
+            "regjsparser": "^0.6.0",
+            "unicode-match-property-ecmascript": "^1.0.4",
+            "unicode-match-property-value-ecmascript": "^1.0.2"
+          }
+        },
+        "registry-auth-token": {
+          "version": "3.3.2",
+          "dev": true,
+          "requires": {
+            "rc": "^1.1.6",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "registry-url": {
+          "version": "3.1.0",
+          "dev": true,
+          "requires": {
+            "rc": "^1.0.1"
+          }
+        },
+        "regjsgen": {
+          "version": "0.5.0",
+          "dev": true
+        },
+        "regjsparser": {
+          "version": "0.6.0",
+          "dev": true,
+          "requires": {
+            "jsesc": "~0.5.0"
+          },
+          "dependencies": {
+            "jsesc": {
+              "version": "0.5.0",
+              "dev": true
+            }
+          }
+        },
+        "relateurl": {
+          "version": "0.2.7",
+          "dev": true
+        },
+        "remove-trailing-separator": {
+          "version": "1.1.0",
+          "dev": true
+        },
+        "repeat-element": {
+          "version": "1.1.3",
+          "dev": true
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "dev": true
+        },
+        "repeating": {
+          "version": "2.0.1",
+          "dev": true,
+          "requires": {
+            "is-finite": "^1.0.0"
+          }
+        },
+        "replace-ext": {
+          "version": "0.0.1",
+          "dev": true
+        },
+        "request": {
+          "version": "2.88.0",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.0",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.4.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          }
+        },
+        "requirejs": {
+          "version": "2.3.6",
+          "dev": true
+        },
+        "requires-port": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.10.0",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
+        "resolve-dir": {
+          "version": "0.1.1",
+          "dev": true,
+          "requires": {
+            "expand-tilde": "^1.2.2",
+            "global-modules": "^0.2.3"
+          }
+        },
+        "resolve-url": {
+          "version": "0.2.1",
+          "dev": true
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "dev": true,
+          "requires": {
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
+          }
+        },
+        "ret": {
+          "version": "0.1.15",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "rollup": {
+          "version": "1.4.0",
+          "dev": true,
+          "requires": {
+            "@types/estree": "0.0.39",
+            "@types/node": "^11.9.5",
+            "acorn": "^6.1.1"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "6.1.1",
+              "dev": true
+            }
+          }
+        },
+        "run-async": {
+          "version": "2.3.0",
+          "dev": true,
+          "requires": {
+            "is-promise": "^2.1.0"
+          }
+        },
+        "rx": {
+          "version": "4.1.0",
+          "dev": true
+        },
+        "rxjs": {
+          "version": "6.4.0",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "dev": true
+        },
+        "safe-regex": {
+          "version": "1.1.0",
+          "dev": true,
+          "requires": {
+            "ret": "~0.1.10"
+          }
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "dev": true
+        },
+        "samsam": {
+          "version": "1.3.0",
+          "dev": true
+        },
+        "sauce-connect-launcher": {
+          "version": "1.2.4",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "adm-zip": "~0.4.3",
+            "async": "^2.1.2",
+            "https-proxy-agent": "^2.2.1",
+            "lodash": "^4.16.6",
+            "rimraf": "^2.5.4"
+          }
+        },
+        "scoped-regex": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "select-hose": {
+          "version": "2.0.0",
+          "dev": true
+        },
+        "selenium-standalone": {
+          "version": "6.15.6",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "async": "^2.6.2",
+            "commander": "^2.19.0",
+            "cross-spawn": "^6.0.5",
+            "debug": "^4.1.1",
+            "lodash": "^4.17.11",
+            "minimist": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "progress": "2.0.3",
+            "request": "2.88.0",
+            "tar-stream": "2.0.0",
+            "urijs": "^1.19.1",
+            "which": "^1.3.1",
+            "yauzl": "^2.10.0"
+          },
+          "dependencies": {
+            "bl": {
+              "version": "2.2.0",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "readable-stream": "^2.3.5",
+                "safe-buffer": "^5.1.1"
+              },
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.3.6",
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.3",
+                    "isarray": "~1.0.0",
+                    "process-nextick-args": "~2.0.0",
+                    "safe-buffer": "~5.1.1",
+                    "string_decoder": "~1.1.1",
+                    "util-deprecate": "~1.0.1"
+                  }
+                }
+              }
+            },
+            "commander": {
+              "version": "2.19.0",
+              "dev": true,
+              "optional": true
+            },
+            "debug": {
+              "version": "4.1.1",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "ms": {
+              "version": "2.1.1",
+              "dev": true,
+              "optional": true
+            },
+            "readable-stream": {
+              "version": "3.2.0",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+              }
+            },
+            "tar-stream": {
+              "version": "2.0.0",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "bl": "^2.2.0",
+                "end-of-stream": "^1.4.1",
+                "fs-constants": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1"
+              }
+            }
+          }
+        },
+        "semver": {
+          "version": "5.6.0",
+          "dev": true
+        },
+        "semver-diff": {
+          "version": "2.1.0",
+          "dev": true,
+          "requires": {
+            "semver": "^5.0.3"
+          }
+        },
+        "send": {
+          "version": "0.16.2",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "depd": "~1.1.2",
+            "destroy": "~1.0.4",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
+            "fresh": "0.5.2",
+            "http-errors": "~1.6.2",
+            "mime": "1.4.1",
+            "ms": "2.0.0",
+            "on-finished": "~2.3.0",
+            "range-parser": "~1.2.0",
+            "statuses": "~1.4.0"
+          },
+          "dependencies": {
+            "mime": {
+              "version": "1.4.1",
+              "dev": true
+            }
+          }
+        },
+        "serve-static": {
+          "version": "1.13.2",
+          "dev": true,
+          "requires": {
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "parseurl": "~1.3.2",
+            "send": "0.16.2"
+          }
+        },
+        "server-destroy": {
+          "version": "1.0.1",
+          "dev": true
+        },
+        "serviceworker-cache-polyfill": {
+          "version": "4.0.0",
+          "dev": true
+        },
+        "set-value": {
+          "version": "2.0.0",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.3",
+            "split-string": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "setprototypeof": {
+          "version": "1.1.0",
+          "dev": true
+        },
+        "shady-css-parser": {
+          "version": "0.1.0",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "shelljs": {
+          "version": "0.8.3",
+          "dev": true,
+          "requires": {
+            "glob": "^7.0.0",
+            "interpret": "^1.0.0",
+            "rechoir": "^0.6.2"
+          }
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "dev": true
+        },
+        "simple-swizzle": {
+          "version": "0.2.2",
+          "dev": true,
+          "requires": {
+            "is-arrayish": "^0.3.1"
+          },
+          "dependencies": {
+            "is-arrayish": {
+              "version": "0.3.2",
+              "dev": true
+            }
+          }
+        },
+        "sinon-chai": {
+          "version": "2.14.0",
+          "dev": true,
+          "requires": {}
+        },
+        "slash": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "slide": {
+          "version": "1.1.6",
+          "dev": true
+        },
+        "snapdragon": {
+          "version": "0.8.2",
+          "dev": true,
+          "requires": {
+            "base": "^0.11.1",
+            "debug": "^2.2.0",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "map-cache": "^0.2.2",
+            "source-map": "^0.5.6",
+            "source-map-resolve": "^0.5.0",
+            "use": "^3.1.0"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "snapdragon-node": {
+          "version": "2.1.1",
+          "dev": true,
+          "requires": {
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.0",
+            "snapdragon-util": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "dev": true
+            }
+          }
+        },
+        "snapdragon-util": {
+          "version": "3.0.1",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.2.0"
+          }
+        },
+        "socket.io": {
+          "version": "2.2.0",
+          "dev": true,
+          "requires": {
+            "debug": "~4.1.0",
+            "engine.io": "~3.3.1",
+            "has-binary2": "~1.0.2",
+            "socket.io-adapter": "~1.1.0",
+            "socket.io-client": "2.2.0",
+            "socket.io-parser": "~3.3.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.1.1",
+              "dev": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "ms": {
+              "version": "2.1.1",
+              "dev": true
+            }
+          }
+        },
+        "socket.io-adapter": {
+          "version": "1.1.1",
+          "dev": true
+        },
+        "socket.io-client": {
+          "version": "2.2.0",
+          "dev": true,
+          "requires": {
+            "backo2": "1.0.2",
+            "base64-arraybuffer": "0.1.5",
+            "component-bind": "1.0.0",
+            "component-emitter": "1.2.1",
+            "debug": "~3.1.0",
+            "engine.io-client": "~3.3.1",
+            "has-binary2": "~1.0.2",
+            "has-cors": "1.1.0",
+            "indexof": "0.0.1",
+            "object-component": "0.0.3",
+            "parseqs": "0.0.5",
+            "parseuri": "0.0.5",
+            "socket.io-parser": "~3.3.0",
+            "to-array": "0.1.4"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "socket.io-parser": {
+          "version": "3.3.0",
+          "dev": true,
+          "requires": {
+            "component-emitter": "1.2.1",
+            "debug": "~3.1.0",
+            "isarray": "2.0.1"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "isarray": {
+              "version": "2.0.1",
+              "dev": true
+            }
+          }
+        },
+        "sort-keys": {
+          "version": "1.1.2",
+          "dev": true,
+          "requires": {
+            "is-plain-obj": "^1.0.0"
+          }
+        },
+        "sort-keys-length": {
+          "version": "1.0.1",
+          "dev": true,
+          "requires": {
+            "sort-keys": "^1.0.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "dev": true
+        },
+        "source-map-resolve": {
+          "version": "0.5.2",
+          "dev": true,
+          "requires": {
+            "atob": "^2.1.1",
+            "decode-uri-component": "^0.2.0",
+            "resolve-url": "^0.2.1",
+            "source-map-url": "^0.4.0",
+            "urix": "^0.1.0"
+          }
+        },
+        "source-map-url": {
+          "version": "0.4.0",
+          "dev": true
+        },
+        "spawn-sync": {
+          "version": "1.0.15",
+          "dev": true,
+          "requires": {
+            "concat-stream": "^1.4.7",
+            "os-shim": "^0.1.2"
+          }
+        },
+        "spdx-correct": {
+          "version": "3.1.0",
+          "dev": true,
+          "requires": {
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-exceptions": {
+          "version": "2.2.0",
+          "dev": true
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.0",
+          "dev": true,
+          "requires": {
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "3.0.3",
+          "dev": true
+        },
+        "spdy": {
+          "version": "3.4.7",
+          "dev": true,
+          "requires": {
+            "debug": "^2.6.8",
+            "handle-thing": "^1.2.5",
+            "http-deceiver": "^1.2.7",
+            "safe-buffer": "^5.0.1",
+            "select-hose": "^2.0.0",
+            "spdy-transport": "^2.0.18"
+          }
+        },
+        "spdy-transport": {
+          "version": "2.1.1",
+          "dev": true,
+          "requires": {
+            "debug": "^2.6.8",
+            "detect-node": "^2.0.3",
+            "hpack.js": "^2.1.6",
+            "obuf": "^1.1.1",
+            "readable-stream": "^2.2.9",
+            "safe-buffer": "^5.0.1",
+            "wbuf": "^1.7.2"
+          }
+        },
+        "split-string": {
+          "version": "3.1.0",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^3.0.0"
+          }
+        },
+        "sshpk": {
+          "version": "1.16.1",
+          "dev": true,
+          "requires": {
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.0.2",
+            "tweetnacl": "~0.14.0"
+          }
+        },
+        "stable": {
+          "version": "0.1.8",
+          "dev": true
+        },
+        "stack-trace": {
+          "version": "0.0.10",
+          "dev": true
+        },
+        "stacky": {
+          "version": "1.3.1",
+          "dev": true,
+          "requires": {
+            "chalk": "^1.1.1",
+            "lodash": "^3.0.0"
+          },
+          "dependencies": {
+            "lodash": {
+              "version": "3.10.1",
+              "dev": true
+            }
+          }
+        },
+        "static-extend": {
+          "version": "0.1.2",
+          "dev": true,
+          "requires": {
+            "define-property": "^0.2.5",
+            "object-copy": "^0.1.0"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            }
+          }
+        },
+        "statuses": {
+          "version": "1.4.0",
+          "dev": true
+        },
+        "stream": {
+          "version": "0.0.2",
+          "dev": true,
+          "requires": {
+            "emitter-component": "^1.1.1"
+          }
+        },
+        "stream-shift": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "streamsearch": {
+          "version": "0.1.2",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "string-template": {
+          "version": "0.2.1",
+          "dev": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "dev": true,
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        },
+        "strip-bom-stream": {
+          "version": "1.0.0",
+          "dev": true,
+          "requires": {
+            "first-chunk-stream": "^1.0.0",
+            "strip-bom": "^2.0.0"
+          }
+        },
+        "strip-eof": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "strip-indent": {
+          "version": "1.0.1",
+          "dev": true,
+          "requires": {
+            "get-stdin": "^4.0.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "dev": true
+        },
+        "sw-precache": {
+          "version": "5.2.1",
+          "dev": true,
+          "requires": {
+            "dom-urls": "^1.1.0",
+            "es6-promise": "^4.0.5",
+            "glob": "^7.1.1",
+            "lodash.defaults": "^4.2.0",
+            "lodash.template": "^4.4.0",
+            "meow": "^3.7.0",
+            "mkdirp": "^0.5.1",
+            "pretty-bytes": "^4.0.2",
+            "sw-toolbox": "^3.4.0",
+            "update-notifier": "^2.3.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "3.2.1",
+              "dev": true,
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            },
+            "update-notifier": {
+              "version": "2.5.0",
+              "dev": true,
+              "requires": {
+                "boxen": "^1.2.1",
+                "chalk": "^2.0.1",
+                "configstore": "^3.0.0",
+                "import-lazy": "^2.1.0",
+                "is-ci": "^1.0.10",
+                "is-installed-globally": "^0.1.0",
+                "is-npm": "^1.0.0",
+                "latest-version": "^3.0.0",
+                "semver-diff": "^2.0.0",
+                "xdg-basedir": "^3.0.0"
+              }
+            }
+          }
+        },
+        "sw-toolbox": {
+          "version": "3.6.0",
+          "dev": true,
+          "requires": {
+            "path-to-regexp": "^1.0.1",
+            "serviceworker-cache-polyfill": "^4.0.0"
+          }
+        },
+        "table-layout": {
+          "version": "0.4.4",
+          "dev": true,
+          "requires": {
+            "array-back": "^2.0.0",
+            "deep-extend": "~0.6.0",
+            "lodash.padend": "^4.6.1",
+            "typical": "^2.6.1",
+            "wordwrapjs": "^3.0.0"
+          },
+          "dependencies": {
+            "deep-extend": {
+              "version": "0.6.0",
+              "dev": true
+            }
+          }
+        },
+        "tar-fs": {
+          "version": "1.16.3",
+          "dev": true,
+          "requires": {
+            "chownr": "^1.0.1",
+            "mkdirp": "^0.5.1",
+            "pump": "^1.0.0",
+            "tar-stream": "^1.1.2"
+          },
+          "dependencies": {
+            "pump": {
+              "version": "1.0.3",
+              "dev": true,
+              "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+              }
+            }
+          }
+        },
+        "tar-stream": {
+          "version": "1.6.2",
+          "dev": true,
+          "requires": {
+            "bl": "^1.0.0",
+            "buffer-alloc": "^1.2.0",
+            "end-of-stream": "^1.0.0",
+            "fs-constants": "^1.0.0",
+            "readable-stream": "^2.3.0",
+            "to-buffer": "^1.1.1",
+            "xtend": "^4.0.0"
+          }
+        },
+        "temp": {
+          "version": "0.8.3",
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "^1.0.0",
+            "rimraf": "~2.2.6"
+          },
+          "dependencies": {
+            "rimraf": {
+              "version": "2.2.8",
+              "dev": true
+            }
+          }
+        },
+        "term-size": {
+          "version": "1.2.0",
+          "dev": true,
+          "requires": {
+            "execa": "^0.7.0"
+          },
+          "dependencies": {
+            "cross-spawn": {
+              "version": "5.1.0",
+              "dev": true,
+              "requires": {
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            },
+            "execa": {
+              "version": "0.7.0",
+              "dev": true,
+              "requires": {
+                "cross-spawn": "^5.0.1",
+                "get-stream": "^3.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
+              }
+            }
+          }
+        },
+        "ternary-stream": {
+          "version": "2.0.1",
+          "dev": true,
+          "requires": {
+            "duplexify": "^3.5.0",
+            "fork-stream": "^0.0.4",
+            "merge-stream": "^1.0.0",
+            "through2": "^2.0.1"
+          }
+        },
+        "test-value": {
+          "version": "3.0.0",
+          "dev": true,
+          "requires": {
+            "array-back": "^2.0.0",
+            "typical": "^2.6.1"
+          }
+        },
+        "text-encoding": {
+          "version": "0.6.4",
+          "dev": true
+        },
+        "text-hex": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "dev": true
+        },
+        "textextensions": {
+          "version": "2.4.0",
+          "dev": true
+        },
+        "thenify": {
+          "version": "3.3.0",
+          "dev": true,
+          "requires": {
+            "any-promise": "^1.0.0"
+          }
+        },
+        "thenify-all": {
+          "version": "1.6.0",
+          "dev": true,
+          "requires": {
+            "thenify": ">= 3.1.0 < 4"
+          }
+        },
+        "through": {
+          "version": "2.3.8",
+          "dev": true
+        },
+        "through2": {
+          "version": "2.0.5",
+          "dev": true,
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
+          }
+        },
+        "through2-filter": {
+          "version": "2.0.0",
+          "dev": true,
+          "requires": {
+            "through2": "~2.0.0",
+            "xtend": "~4.0.0"
+          }
+        },
+        "timed-out": {
+          "version": "4.0.1",
+          "dev": true
+        },
+        "to-absolute-glob": {
+          "version": "0.1.1",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "to-array": {
+          "version": "0.1.4",
+          "dev": true
+        },
+        "to-buffer": {
+          "version": "1.1.1",
+          "dev": true
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "dev": true
+        },
+        "to-object-path": {
+          "version": "0.3.0",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "to-regex": {
+          "version": "3.0.2",
+          "dev": true,
+          "requires": {
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "regex-not": "^1.0.2",
+            "safe-regex": "^1.1.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "3.0.0",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              }
+            }
+          }
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "dev": true,
+          "requires": {
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
+          },
+          "dependencies": {
+            "punycode": {
+              "version": "1.4.1",
+              "dev": true
+            }
+          }
+        },
+        "tr46": {
+          "version": "1.0.1",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "trim-newlines": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "trim-right": {
+          "version": "1.0.1",
+          "dev": true
+        },
+        "triple-beam": {
+          "version": "1.3.0",
+          "dev": true
+        },
+        "tslib": {
+          "version": "1.9.3",
+          "dev": true
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "dev": true
+        },
+        "type-detect": {
+          "version": "4.0.8",
+          "dev": true
+        },
+        "type-is": {
+          "version": "1.6.16",
+          "dev": true,
+          "requires": {
+            "media-typer": "0.3.0",
+            "mime-types": "~2.1.18"
+          }
+        },
+        "typedarray": {
+          "version": "0.0.6",
+          "dev": true
+        },
+        "typical": {
+          "version": "2.6.1",
+          "dev": true
+        },
+        "ua-parser-js": {
+          "version": "0.7.19",
+          "dev": true
+        },
+        "uglify-js": {
+          "version": "3.4.9",
+          "dev": true,
+          "requires": {
+            "commander": "~2.17.1",
+            "source-map": "~0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "dev": true
+            }
+          }
+        },
+        "underscore": {
+          "version": "1.6.0",
+          "dev": true
+        },
+        "unicode-canonical-property-names-ecmascript": {
+          "version": "1.0.4",
+          "dev": true
+        },
+        "unicode-match-property-ecmascript": {
+          "version": "1.0.4",
+          "dev": true,
+          "requires": {
+            "unicode-canonical-property-names-ecmascript": "^1.0.4",
+            "unicode-property-aliases-ecmascript": "^1.0.4"
+          }
+        },
+        "unicode-match-property-value-ecmascript": {
+          "version": "1.0.2",
+          "dev": true
+        },
+        "unicode-property-aliases-ecmascript": {
+          "version": "1.0.4",
+          "dev": true
+        },
+        "union-value": {
+          "version": "1.0.0",
+          "dev": true,
+          "requires": {
+            "arr-union": "^3.1.0",
+            "get-value": "^2.0.6",
+            "is-extendable": "^0.1.1",
+            "set-value": "^0.4.3"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "set-value": {
+              "version": "0.4.3",
+              "dev": true,
+              "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.1",
+                "to-object-path": "^0.3.0"
+              }
+            }
+          }
+        },
+        "unique-stream": {
+          "version": "2.3.1",
+          "dev": true,
+          "requires": {
+            "json-stable-stringify-without-jsonify": "^1.0.1",
+            "through2-filter": "^3.0.0"
+          },
+          "dependencies": {
+            "through2-filter": {
+              "version": "3.0.0",
+              "dev": true,
+              "requires": {
+                "through2": "~2.0.0",
+                "xtend": "~4.0.0"
+              }
+            }
+          }
+        },
+        "unique-string": {
+          "version": "1.0.0",
+          "dev": true,
+          "requires": {
+            "crypto-random-string": "^1.0.0"
+          }
+        },
+        "universal-user-agent": {
+          "version": "2.0.3",
+          "dev": true,
+          "requires": {
+            "os-name": "^3.0.0"
+          }
+        },
+        "unpipe": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "unset-value": {
+          "version": "1.0.0",
+          "dev": true,
+          "requires": {
+            "has-value": "^0.3.1",
+            "isobject": "^3.0.0"
+          },
+          "dependencies": {
+            "has-value": {
+              "version": "0.3.1",
+              "dev": true,
+              "requires": {
+                "get-value": "^2.0.3",
+                "has-values": "^0.1.4",
+                "isobject": "^2.0.0"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "2.1.0",
+                  "dev": true,
+                  "requires": {
+                    "isarray": "1.0.0"
+                  }
+                }
+              }
+            },
+            "has-values": {
+              "version": "0.1.4",
+              "dev": true
+            }
+          }
+        },
+        "untildify": {
+          "version": "2.1.0",
+          "dev": true,
+          "requires": {
+            "os-homedir": "^1.0.0"
+          }
+        },
+        "unzip-response": {
+          "version": "2.0.1",
+          "dev": true
+        },
+        "update-notifier": {
+          "version": "1.0.3",
+          "dev": true,
+          "requires": {
+            "boxen": "^0.6.0",
+            "chalk": "^1.0.0",
+            "configstore": "^2.0.0",
+            "is-npm": "^1.0.0",
+            "latest-version": "^2.0.0",
+            "lazy-req": "^1.1.0",
+            "semver-diff": "^2.0.0",
+            "xdg-basedir": "^2.0.0"
+          },
+          "dependencies": {
+            "ansi-align": {
+              "version": "1.1.0",
+              "dev": true,
+              "requires": {
+                "string-width": "^1.0.1"
+              }
+            },
+            "boxen": {
+              "version": "0.6.0",
+              "dev": true,
+              "requires": {
+                "ansi-align": "^1.1.0",
+                "camelcase": "^2.1.0",
+                "chalk": "^1.1.1",
+                "cli-boxes": "^1.0.0",
+                "filled-array": "^1.0.0",
+                "object-assign": "^4.0.1",
+                "repeating": "^2.0.0",
+                "string-width": "^1.0.1",
+                "widest-line": "^1.0.0"
+              }
+            },
+            "configstore": {
+              "version": "2.1.0",
+              "dev": true,
+              "requires": {
+                "dot-prop": "^3.0.0",
+                "graceful-fs": "^4.1.2",
+                "mkdirp": "^0.5.0",
+                "object-assign": "^4.0.1",
+                "os-tmpdir": "^1.0.0",
+                "osenv": "^0.1.0",
+                "uuid": "^2.0.1",
+                "write-file-atomic": "^1.1.2",
+                "xdg-basedir": "^2.0.0"
+              }
+            },
+            "dot-prop": {
+              "version": "3.0.0",
+              "dev": true,
+              "requires": {
+                "is-obj": "^1.0.0"
+              }
+            },
+            "got": {
+              "version": "5.7.1",
+              "dev": true,
+              "requires": {
+                "create-error-class": "^3.0.1",
+                "duplexer2": "^0.1.4",
+                "is-redirect": "^1.0.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "lowercase-keys": "^1.0.0",
+                "node-status-codes": "^1.0.0",
+                "object-assign": "^4.0.1",
+                "parse-json": "^2.1.0",
+                "pinkie-promise": "^2.0.0",
+                "read-all-stream": "^3.0.0",
+                "readable-stream": "^2.0.5",
+                "timed-out": "^3.0.0",
+                "unzip-response": "^1.0.2",
+                "url-parse-lax": "^1.0.0"
+              }
+            },
+            "latest-version": {
+              "version": "2.0.0",
+              "dev": true,
+              "requires": {
+                "package-json": "^2.0.0"
+              }
+            },
+            "package-json": {
+              "version": "2.4.0",
+              "dev": true,
+              "requires": {
+                "got": "^5.0.0",
+                "registry-auth-token": "^3.0.1",
+                "registry-url": "^3.0.3",
+                "semver": "^5.1.0"
+              }
+            },
+            "timed-out": {
+              "version": "3.1.3",
+              "dev": true
+            },
+            "unzip-response": {
+              "version": "1.0.2",
+              "dev": true
+            },
+            "uuid": {
+              "version": "2.0.3",
+              "dev": true
+            },
+            "widest-line": {
+              "version": "1.0.0",
+              "dev": true,
+              "requires": {
+                "string-width": "^1.0.1"
+              }
+            },
+            "write-file-atomic": {
+              "version": "1.3.4",
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.11",
+                "imurmurhash": "^0.1.4",
+                "slide": "^1.1.5"
+              }
+            },
+            "xdg-basedir": {
+              "version": "2.0.0",
+              "dev": true,
+              "requires": {
+                "os-homedir": "^1.0.0"
+              }
+            }
+          }
+        },
+        "upper-case": {
+          "version": "1.1.3",
+          "dev": true
+        },
+        "uri-js": {
+          "version": "4.2.2",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "urijs": {
+          "version": "1.19.1",
+          "dev": true
+        },
+        "urix": {
+          "version": "0.1.0",
+          "dev": true
+        },
+        "url-parse-lax": {
+          "version": "1.0.0",
+          "dev": true,
+          "requires": {
+            "prepend-http": "^1.0.1"
+          }
+        },
+        "url-template": {
+          "version": "2.0.8",
+          "dev": true
+        },
+        "url-to-options": {
+          "version": "1.0.1",
+          "dev": true
+        },
+        "use": {
+          "version": "3.1.1",
+          "dev": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "dev": true
+        },
+        "utils-merge": {
+          "version": "1.0.1",
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "dev": true
+        },
+        "vali-date": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "validate-element-name": {
+          "version": "2.1.1",
+          "dev": true,
+          "requires": {
+            "is-potential-custom-element-name": "^1.0.0",
+            "log-symbols": "^1.0.0",
+            "meow": "^3.7.0"
+          }
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.4",
+          "dev": true,
+          "requires": {
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
+          }
+        },
+        "vargs": {
+          "version": "0.1.0",
+          "dev": true
+        },
+        "vary": {
+          "version": "1.1.2",
+          "dev": true
+        },
+        "verror": {
+          "version": "1.10.0",
+          "dev": true,
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "^1.2.0"
+          }
+        },
+        "vinyl": {
+          "version": "1.2.0",
+          "dev": true,
+          "requires": {
+            "clone": "^1.0.0",
+            "clone-stats": "^0.0.1",
+            "replace-ext": "0.0.1"
+          },
+          "dependencies": {
+            "clone": {
+              "version": "1.0.4",
+              "dev": true
+            }
+          }
+        },
+        "vinyl-file": {
+          "version": "2.0.0",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.3.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0",
+            "strip-bom-stream": "^2.0.0",
+            "vinyl": "^1.1.0"
+          },
+          "dependencies": {
+            "first-chunk-stream": {
+              "version": "2.0.0",
+              "dev": true,
+              "requires": {
+                "readable-stream": "^2.0.2"
+              }
+            },
+            "strip-bom-stream": {
+              "version": "2.0.0",
+              "dev": true,
+              "requires": {
+                "first-chunk-stream": "^2.0.0",
+                "strip-bom": "^2.0.0"
+              }
+            }
+          }
+        },
+        "vinyl-fs": {
+          "version": "2.4.4",
+          "dev": true,
+          "requires": {
+            "duplexify": "^3.2.0",
+            "glob-stream": "^5.3.2",
+            "graceful-fs": "^4.0.0",
+            "gulp-sourcemaps": "1.6.0",
+            "is-valid-glob": "^0.3.0",
+            "lazystream": "^1.0.0",
+            "lodash.isequal": "^4.0.0",
+            "merge-stream": "^1.0.0",
+            "mkdirp": "^0.5.0",
+            "object-assign": "^4.0.0",
+            "readable-stream": "^2.0.4",
+            "strip-bom": "^2.0.0",
+            "strip-bom-stream": "^1.0.0",
+            "through2": "^2.0.0",
+            "through2-filter": "^2.0.0",
+            "vali-date": "^1.0.0",
+            "vinyl": "^1.0.0"
+          }
+        },
+        "vlq": {
+          "version": "0.2.3",
+          "dev": true
+        },
+        "vscode-uri": {
+          "version": "1.0.6",
+          "dev": true
+        },
+        "wbuf": {
+          "version": "1.7.3",
+          "dev": true,
+          "requires": {
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "wct-local": {
+          "version": "2.1.3",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@types/express": "^4.0.30",
+            "@types/freeport": "^1.0.19",
+            "@types/launchpad": "^0.6.0",
+            "@types/which": "^1.3.1",
+            "chalk": "^2.3.0",
+            "cleankill": "^2.0.0",
+            "freeport": "^1.0.4",
+            "launchpad": "^0.7.0",
+            "selenium-standalone": "^6.7.0",
+            "which": "^1.0.8"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "3.2.1",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "wct-sauce": {
+          "version": "2.1.0",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "cleankill": "^2.0.0",
+            "lodash": "^4.17.10",
+            "request": "^2.85.0",
+            "sauce-connect-launcher": "^1.0.0",
+            "temp": "^0.8.1",
+            "uuid": "^3.2.1"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "3.2.1",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "wd": {
+          "version": "1.11.1",
+          "dev": true,
+          "requires": {
+            "archiver": "2.1.1",
+            "async": "2.0.1",
+            "lodash": "4.17.11",
+            "mkdirp": "^0.5.1",
+            "q": "1.4.1",
+            "request": "2.88.0",
+            "vargs": "0.1.0"
+          },
+          "dependencies": {
+            "async": {
+              "version": "2.0.1",
+              "dev": true,
+              "requires": {
+                "lodash": "^4.8.0"
+              }
+            },
+            "q": {
+              "version": "1.4.1",
+              "dev": true
+            }
+          }
+        },
+        "web-component-tester": {
+          "version": "6.9.2",
+          "dev": true,
+          "requires": {
+            "@polymer/sinonjs": "^1.14.1",
+            "@polymer/test-fixture": "^0.0.3",
+            "@webcomponents/webcomponentsjs": "^1.0.7",
+            "accessibility-developer-tools": "^2.12.0",
+            "async": "^2.4.1",
+            "body-parser": "^1.17.2",
+            "bower-config": "^1.4.0",
+            "chalk": "^1.1.3",
+            "cleankill": "^2.0.0",
+            "express": "^4.15.3",
+            "findup-sync": "^2.0.0",
+            "glob": "^7.1.2",
+            "lodash": "^3.10.1",
+            "multer": "^1.3.0",
+            "nomnom": "^1.8.1",
+            "polyserve": "^0.27.13",
+            "resolve": "^1.5.0",
+            "semver": "^5.3.0",
+            "send": "^0.16.1",
+            "server-destroy": "^1.0.1",
+            "sinon": "^2.3.5",
+            "sinon-chai": "^2.10.0",
+            "socket.io": "^2.0.3",
+            "stacky": "^1.3.1",
+            "update-notifier": "^2.2.0",
+            "wct-local": "^2.1.1",
+            "wct-sauce": "^2.0.2",
+            "wd": "^1.2.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "3.2.1",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "arr-diff": {
+              "version": "4.0.0",
+              "dev": true
+            },
+            "array-unique": {
+              "version": "0.3.2",
+              "dev": true
+            },
+            "braces": {
+              "version": "2.3.2",
+              "dev": true,
+              "requires": {
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "dev": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "detect-file": {
+              "version": "1.0.0",
+              "dev": true
+            },
+            "expand-brackets": {
+              "version": "2.1.4",
+              "dev": true,
+              "requires": {
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "0.2.5",
+                  "dev": true,
+                  "requires": {
+                    "is-descriptor": "^0.1.0"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "dev": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                },
+                "is-accessor-descriptor": {
+                  "version": "0.1.6",
+                  "dev": true,
+                  "requires": {
+                    "kind-of": "^3.0.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "dev": true,
+                      "requires": {
+                        "is-buffer": "^1.1.5"
+                      }
+                    }
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "0.1.4",
+                  "dev": true,
+                  "requires": {
+                    "kind-of": "^3.0.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "dev": true,
+                      "requires": {
+                        "is-buffer": "^1.1.5"
+                      }
+                    }
+                  }
+                },
+                "is-descriptor": {
+                  "version": "0.1.6",
+                  "dev": true,
+                  "requires": {
+                    "is-accessor-descriptor": "^0.1.6",
+                    "is-data-descriptor": "^0.1.4",
+                    "kind-of": "^5.0.0"
+                  }
+                },
+                "kind-of": {
+                  "version": "5.1.0",
+                  "dev": true
+                }
+              }
+            },
+            "expand-tilde": {
+              "version": "2.0.2",
+              "dev": true,
+              "requires": {
+                "homedir-polyfill": "^1.0.1"
+              }
+            },
+            "extglob": {
+              "version": "2.0.4",
+              "dev": true,
+              "requires": {
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "1.0.0",
+                  "dev": true,
+                  "requires": {
+                    "is-descriptor": "^1.0.0"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "dev": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "fill-range": {
+              "version": "4.0.0",
+              "dev": true,
+              "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "dev": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "findup-sync": {
+              "version": "2.0.0",
+              "dev": true,
+              "requires": {
+                "detect-file": "^1.0.0",
+                "is-glob": "^3.1.0",
+                "micromatch": "^3.0.4",
+                "resolve-dir": "^1.0.1"
+              }
+            },
+            "global-modules": {
+              "version": "1.0.0",
+              "dev": true,
+              "requires": {
+                "global-prefix": "^1.0.1",
+                "is-windows": "^1.0.1",
+                "resolve-dir": "^1.0.0"
+              }
+            },
+            "global-prefix": {
+              "version": "1.0.2",
+              "dev": true,
+              "requires": {
+                "expand-tilde": "^2.0.2",
+                "homedir-polyfill": "^1.0.1",
+                "ini": "^1.3.4",
+                "is-windows": "^1.0.1",
+                "which": "^1.2.14"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            },
+            "is-extglob": {
+              "version": "2.1.1",
+              "dev": true
+            },
+            "is-glob": {
+              "version": "3.1.0",
+              "dev": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            },
+            "is-number": {
+              "version": "3.0.0",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "dev": true
+            },
+            "lodash": {
+              "version": "3.10.1",
+              "dev": true
+            },
+            "micromatch": {
+              "version": "3.1.10",
+              "dev": true,
+              "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
+              }
+            },
+            "resolve-dir": {
+              "version": "1.0.1",
+              "dev": true,
+              "requires": {
+                "expand-tilde": "^2.0.0",
+                "global-modules": "^1.0.0"
+              }
+            },
+            "sinon": {
+              "version": "2.4.1",
+              "dev": true,
+              "requires": {
+                "diff": "^3.1.0",
+                "formatio": "1.2.0",
+                "lolex": "^1.6.0",
+                "native-promise-only": "^0.8.1",
+                "path-to-regexp": "^1.7.0",
+                "samsam": "^1.1.3",
+                "text-encoding": "0.6.4",
+                "type-detect": "^4.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            },
+            "update-notifier": {
+              "version": "2.5.0",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "boxen": "^1.2.1",
+                "chalk": "^2.0.1",
+                "configstore": "^3.0.0",
+                "import-lazy": "^2.1.0",
+                "is-ci": "^1.0.10",
+                "is-installed-globally": "^0.1.0",
+                "is-npm": "^1.0.0",
+                "latest-version": "^3.0.0",
+                "semver-diff": "^2.0.0",
+                "xdg-basedir": "^3.0.0"
+              },
+              "dependencies": {
+                "chalk": {
+                  "version": "2.4.2",
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "ansi-styles": "^3.2.1",
+                    "escape-string-regexp": "^1.0.5",
+                    "supports-color": "^5.3.0"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "webidl-conversions": {
+          "version": "4.0.2",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "6.5.0",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "widest-line": {
+          "version": "2.0.1",
+          "dev": true,
+          "requires": {
+            "string-width": "^2.1.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "dev": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "dev": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "windows-release": {
+          "version": "3.1.0",
+          "dev": true,
+          "requires": {
+            "execa": "^0.10.0"
+          }
+        },
+        "winston": {
+          "version": "3.2.1",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.1",
+            "diagnostics": "^1.1.1",
+            "is-stream": "^1.1.0",
+            "logform": "^2.1.1",
+            "one-time": "0.0.4",
+            "readable-stream": "^3.1.1",
+            "stack-trace": "0.0.x",
+            "triple-beam": "^1.3.0",
+            "winston-transport": "^4.3.0"
+          },
+          "dependencies": {
+            "logform": {
+              "version": "2.1.2",
+              "dev": true,
+              "requires": {
+                "colors": "^1.2.1",
+                "fast-safe-stringify": "^2.0.4",
+                "fecha": "^2.3.3",
+                "ms": "^2.1.1",
+                "triple-beam": "^1.3.0"
+              }
+            },
+            "ms": {
+              "version": "2.1.1",
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "3.2.0",
+              "dev": true,
+              "requires": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+              }
+            }
+          }
+        },
+        "winston-transport": {
+          "version": "4.3.0",
+          "dev": true,
+          "requires": {
+            "readable-stream": "^2.3.6",
+            "triple-beam": "^1.2.0"
+          }
+        },
+        "with-open-file": {
+          "version": "0.1.5",
+          "dev": true,
+          "requires": {
+            "p-finally": "^1.0.0",
+            "p-try": "^2.0.0",
+            "pify": "^3.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "3.0.0",
+              "dev": true
+            }
+          }
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "dev": true
+        },
+        "wordwrapjs": {
+          "version": "3.0.0",
+          "dev": true,
+          "requires": {
+            "reduce-flatten": "^1.0.1",
+            "typical": "^2.6.1"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "dev": true
+        },
+        "write-file-atomic": {
+          "version": "2.4.2",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "ws": {
+          "version": "6.1.4",
+          "dev": true,
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        },
+        "xdg-basedir": {
+          "version": "3.0.0",
+          "dev": true
+        },
+        "xmlbuilder": {
+          "version": "8.2.2",
+          "dev": true,
+          "optional": true
+        },
+        "xmldom": {
+          "version": "0.1.27",
+          "dev": true,
+          "optional": true
+        },
+        "xmlhttprequest-ssl": {
+          "version": "1.5.5",
+          "dev": true
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "dev": true
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "dev": true
+        },
+        "yauzl": {
+          "version": "2.10.0",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "buffer-crc32": "~0.2.3",
+            "fd-slicer": "~1.1.0"
+          }
+        },
+        "yeast": {
+          "version": "0.1.2",
+          "dev": true
+        },
+        "yeoman-environment": {
+          "version": "1.6.6",
+          "dev": true,
+          "requires": {
+            "chalk": "^1.0.0",
+            "debug": "^2.0.0",
+            "diff": "^2.1.2",
+            "escape-string-regexp": "^1.0.2",
+            "globby": "^4.0.0",
+            "grouped-queue": "^0.3.0",
+            "inquirer": "^1.0.2",
+            "lodash": "^4.11.1",
+            "log-symbols": "^1.0.1",
+            "mem-fs": "^1.1.0",
+            "text-table": "^0.2.0",
+            "untildify": "^2.0.0"
+          },
+          "dependencies": {
+            "diff": {
+              "version": "2.2.3",
+              "dev": true
+            },
+            "glob": {
+              "version": "6.0.4",
+              "dev": true,
+              "requires": {
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "2 || 3",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "globby": {
+              "version": "4.1.0",
+              "dev": true,
+              "requires": {
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "glob": "^6.0.1",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            }
+          }
+        },
+        "yeoman-generator": {
+          "version": "3.2.0",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.0",
+            "chalk": "^2.3.0",
+            "cli-table": "^0.3.1",
+            "cross-spawn": "^6.0.5",
+            "dargs": "^6.0.0",
+            "dateformat": "^3.0.3",
+            "debug": "^4.1.0",
+            "detect-conflict": "^1.0.0",
+            "error": "^7.0.2",
+            "find-up": "^3.0.0",
+            "github-username": "^4.0.0",
+            "istextorbinary": "^2.2.1",
+            "lodash": "^4.17.10",
+            "make-dir": "^1.1.0",
+            "mem-fs-editor": "^5.0.0",
+            "minimist": "^1.2.0",
+            "pretty-bytes": "^5.1.0",
+            "read-chunk": "^3.0.0",
+            "read-pkg-up": "^4.0.0",
+            "rimraf": "^2.6.2",
+            "run-async": "^2.0.0",
+            "shelljs": "^0.8.0",
+            "text-table": "^0.2.0",
+            "through2": "^3.0.0",
+            "yeoman-environment": "^2.0.5"
+          },
+          "dependencies": {
+            "ansi-escapes": {
+              "version": "3.2.0",
+              "dev": true
+            },
+            "ansi-regex": {
+              "version": "3.0.0",
+              "dev": true
+            },
+            "ansi-styles": {
+              "version": "3.2.1",
+              "dev": true,
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "cli-cursor": {
+              "version": "2.1.0",
+              "dev": true,
+              "requires": {
+                "restore-cursor": "^2.0.0"
+              }
+            },
+            "debug": {
+              "version": "4.1.1",
+              "dev": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "external-editor": {
+              "version": "3.0.3",
+              "dev": true,
+              "requires": {
+                "chardet": "^0.7.0",
+                "iconv-lite": "^0.4.24",
+                "tmp": "^0.0.33"
+              }
+            },
+            "figures": {
+              "version": "2.0.0",
+              "dev": true,
+              "requires": {
+                "escape-string-regexp": "^1.0.5"
+              }
+            },
+            "find-up": {
+              "version": "3.0.0",
+              "dev": true,
+              "requires": {
+                "locate-path": "^3.0.0"
+              }
+            },
+            "iconv-lite": {
+              "version": "0.4.24",
+              "dev": true,
+              "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+              }
+            },
+            "inquirer": {
+              "version": "6.2.2",
+              "dev": true,
+              "requires": {
+                "ansi-escapes": "^3.2.0",
+                "chalk": "^2.4.2",
+                "cli-cursor": "^2.1.0",
+                "cli-width": "^2.0.0",
+                "external-editor": "^3.0.3",
+                "figures": "^2.0.0",
+                "lodash": "^4.17.11",
+                "mute-stream": "0.0.7",
+                "run-async": "^2.2.0",
+                "rxjs": "^6.4.0",
+                "string-width": "^2.1.0",
+                "strip-ansi": "^5.0.0",
+                "through": "^2.3.6"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "4.0.0",
+                  "dev": true
+                },
+                "strip-ansi": {
+                  "version": "5.0.0",
+                  "dev": true,
+                  "requires": {
+                    "ansi-regex": "^4.0.0"
+                  }
+                }
+              }
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "dev": true
+            },
+            "load-json-file": {
+              "version": "4.0.0",
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^4.0.0",
+                "pify": "^3.0.0",
+                "strip-bom": "^3.0.0"
+              }
+            },
+            "log-symbols": {
+              "version": "2.2.0",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.0.1"
+              }
+            },
+            "ms": {
+              "version": "2.1.1",
+              "dev": true
+            },
+            "mute-stream": {
+              "version": "0.0.7",
+              "dev": true
+            },
+            "onetime": {
+              "version": "2.0.1",
+              "dev": true,
+              "requires": {
+                "mimic-fn": "^1.0.0"
+              }
+            },
+            "parse-json": {
+              "version": "4.0.0",
+              "dev": true,
+              "requires": {
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
+              }
+            },
+            "path-type": {
+              "version": "3.0.0",
+              "dev": true,
+              "requires": {
+                "pify": "^3.0.0"
+              }
+            },
+            "pify": {
+              "version": "3.0.0",
+              "dev": true
+            },
+            "pretty-bytes": {
+              "version": "5.1.0",
+              "dev": true
+            },
+            "read-pkg": {
+              "version": "3.0.0",
+              "dev": true,
+              "requires": {
+                "load-json-file": "^4.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^3.0.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "4.0.0",
+              "dev": true,
+              "requires": {
+                "find-up": "^3.0.0",
+                "read-pkg": "^3.0.0"
+              }
+            },
+            "restore-cursor": {
+              "version": "2.0.0",
+              "dev": true,
+              "requires": {
+                "onetime": "^2.0.0",
+                "signal-exit": "^3.0.2"
+              }
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "dev": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            },
+            "strip-bom": {
+              "version": "3.0.0",
+              "dev": true
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            },
+            "through2": {
+              "version": "3.0.1",
+              "dev": true,
+              "requires": {
+                "readable-stream": "2 || 3"
+              }
+            },
+            "tmp": {
+              "version": "0.0.33",
+              "dev": true,
+              "requires": {
+                "os-tmpdir": "~1.0.2"
+              }
+            },
+            "untildify": {
+              "version": "3.0.3",
+              "dev": true
+            },
+            "yeoman-environment": {
+              "version": "2.3.4",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "cross-spawn": "^6.0.5",
+                "debug": "^3.1.0",
+                "diff": "^3.5.0",
+                "escape-string-regexp": "^1.0.2",
+                "globby": "^8.0.1",
+                "grouped-queue": "^0.3.3",
+                "inquirer": "^6.0.0",
+                "is-scoped": "^1.0.0",
+                "lodash": "^4.17.10",
+                "log-symbols": "^2.2.0",
+                "mem-fs": "^1.1.0",
+                "strip-ansi": "^4.0.0",
+                "text-table": "^0.2.0",
+                "untildify": "^3.0.3"
+              },
+              "dependencies": {
+                "debug": {
+                  "version": "3.2.6",
+                  "dev": true,
+                  "requires": {
+                    "ms": "^2.1.1"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "zip-stream": {
+          "version": "1.2.0",
+          "dev": true,
+          "requires": {
+            "archiver-utils": "^1.3.0",
+            "compress-commons": "^1.2.0",
+            "lodash": "^4.8.0",
+            "readable-stream": "^2.0.0"
+          }
+        }
+      }
+    },
+    "regenerator-runtime": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+      "optional": true
+    },
+    "samsam": {
+      "version": "1.1.2",
+      "dev": true
+    },
+    "sinon": {
+      "version": "1.17.7",
+      "dev": true,
+      "requires": {
+        "formatio": "1.1.1",
+        "lolex": "1.3.2",
+        "samsam": "1.1.2",
+        "util": ">=0.10.3 <1"
+      }
+    },
+    "sinon-chai": {
+      "version": "2.14.0",
+      "dev": true,
+      "requires": {}
+    },
+    "stacky": {
+      "version": "1.3.1",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.1",
+        "lodash": "^3.0.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "supports-color": {
+      "version": "3.1.2",
+      "dev": true,
+      "requires": {
+        "has-flag": "^1.0.0"
+      }
+    },
+    "type-detect": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "util": {
+      "version": "0.11.1",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3"
+      }
+    },
+    "wct-browser-legacy": {
+      "version": "1.0.2",
+      "dev": true,
+      "requires": {
+        "@polymer/polymer": "^3.0.0",
+        "@polymer/sinonjs": "^1.14.1",
+        "@polymer/test-fixture": "^3.0.0-pre.1",
+        "@webcomponents/webcomponentsjs": "^2.0.0",
+        "accessibility-developer-tools": "^2.12.0",
+        "async": "^1.5.2",
+        "chai": "^3.5.0",
+        "lodash": "^3.10.1",
+        "mocha": "^3.4.2",
+        "sinon": "^1.17.1",
+        "sinon-chai": "^2.10.0",
+        "stacky": "^1.3.1"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "dev": true
+    }
+  }
+}

--- a/webconnector/frontend/package.json
+++ b/webconnector/frontend/package.json
@@ -41,7 +41,7 @@
     "@polymer/paper-tooltip": "^3.0.1",
     "@polymer/polymer": "^3.1.0",
     "@webcomponents/webcomponentsjs": "^2.2.1",
-    "las2peer-frontend-statusbar": "github:rwth-acis/las2peer-frontend-statusbar#0.3.0"
+    "las2peer-frontend-statusbar": "github:rwth-acis/las2peer-frontend-statusbar#0.3.1"
   },
   "devDependencies": {
     "polymer-cli": "^1.9.7",


### PR DESCRIPTION
This pr changes the way the provided service versions are interpreted to adhere to the semver specification.

This should not directly cause any breaking changes, since the previous schema of providing build numbers still works (they are just pre-releases now and can be alphanumeric, but they can still be provided in the same way).

At the same time I renamed the `sub` attribute to `patch` to use the semver notation. The old getter maps to the new one and has been flagged as deprecated.