### PR TITLE
fix http port setting

### DIFF
--- a/webconnector/src/main/java/i5/las2peer/connectors/webConnector/WebConnector.java
+++ b/webconnector/src/main/java/i5/las2peer/connectors/webConnector/WebConnector.java
@@ -423,8 +423,8 @@ public class WebConnector extends Connector {
 		http = GrizzlyHttpServerFactory.createHttpServer(new URI("http://0.0.0.0:"+ httpPort + "/"), config, false);
 		final TCPNIOTransport transport = http.getListener("grizzly").getTransport();
 		transport.setWorkerThreadPoolConfig(ThreadPoolConfig.defaultConfig().setCorePoolSize(maxThreads).setMaxPoolSize(maxThreads));
-		httpPort = http.getListener("grizzly").getPort();
 		http.start();
+		httpPort = http.getListener("grizzly").getPort();
 		logMessage("Web-Connector in HTTP mode running at " + getHttpEndpoint());
 	}
 


### PR DESCRIPTION
This PR fixes the Service Tests for the webconnector. The issue with the existing code was that the httpPort was set before the server has started. The documentation of `getPort()` 
> /**
     * @return the network port to which this listener is configured to bind to.
     * If the {@link HttpServer} has not been started yet - the returned value
     * may be:
     * <tt>-1</tt>, if {@link PortRange} will be used to bind the listener;
     * <tt>0</tt>, if the port will be assigned by OS;
     * <tt>0 < N < 65536</tt>, the port this listener will be bound to.
     * If {@link HttpServer} has been started - the value returned is the port the
     * this listener is bound to.
     */

shows that `getPort()` returns the **configured** port before the server is started and only the **actual** assigned port after the server has been started. 
In our service test case that means that when we set the configured port to 0 ,the configured httPort was assigned 0, before the OS assigns a port to the server. Thus `connector.getHttpEndpoint()` always returned 0 insteat of the assigned port