### PR TITLE
added fix for umlaute

### DIFF
--- a/webconnector/src/main/java/i5/las2peer/connectors/webConnector/client/MiniClient.java
+++ b/webconnector/src/main/java/i5/las2peer/connectors/webConnector/client/MiniClient.java
@@ -108,7 +108,7 @@ public class MiniClient {
 
 				// Send request
 				DataOutputStream wr = new DataOutputStream(connection.getOutputStream());
-				wr.writeBytes(content);
+				wr.write(content.getBytes("UTF-8"));
 				wr.close();
 			}
 


### PR DESCRIPTION
This should fix the problem of Umlaute turning into the weird question mark symbol. 

The problem itself stems from the fact that the UTF-8 encoding (the one containing umlaute) did not get correctly tranformed into bytes. I suppose the ws.getBytes(String content) call transforms the UTF-8 input into ASCII Bytes instead of transforming it into UTF-8 Bytes (presumably). 
This locally fixed the weird question mark problem. 
I didn't do much testing though. I only did 2 miniclient request tests: 

1. Send request to endpoint awaiting string body
2. Send request to endpoint awaiting byte[] body
Both worked correctly, so  I hope that no surprises will show up bcs of this change. 

Fixes #166 
Create 1.2.4 if ok. 

